### PR TITLE
Add host and port specification to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN uv sync
 
 COPY . .
 
-CMD ["uv", "run", "uvicorn", "ai4gd_momconnect_haystack.api:app"]
+CMD ["uv", "run", "uvicorn", "ai4gd_momconnect_haystack.api:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
If we don't specify a host, then uvicorn defaults to localhost, which means it won't be accessible outside of the container.

We need to specify the host explicitly as 0.0.0.0 to allow access outside of localhost
