### PR TITLE
added evaluation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,5 @@ weaviate_data/
 
 # Other files
 .python-version
+.vscode/
+evaluation_outputs/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,6 +27,8 @@ services:
       context: .
     depends_on:
       - weaviate
+    env_file:
+      - .env
     environment:
       WEAVIATE_URL: http://weaviate:8080
       # OPENAI_API_KEY: 'your_openai_api_key_if_needed_by_haystack' # Add other necessary ENV VARS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,7 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "haystack_integrations.*"
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "langfuse.*"
+ignore_missing_imports = true

--- a/src/ai4gd_momconnect_haystack/evaluation/batch_evaluator.py
+++ b/src/ai4gd_momconnect_haystack/evaluation/batch_evaluator.py
@@ -99,7 +99,7 @@ def run_batch_evaluation(scenarios_to_evaluate: list) -> None:
             actual_output = actual_trace.output
             is_match = (actual_output == ground_truth_delta)
             score_value = 1 if is_match else 0
-            comment = (f"SUCCESS: Match." if is_match
+            comment = ("SUCCESS: Match." if is_match
                        else f"FAILURE on user utterance: '{user_utterance}'. Expected {ground_truth_delta}, but got {actual_output}")
 
             score_name = f"{flow_type}_accuracy"

--- a/src/ai4gd_momconnect_haystack/evaluation/batch_evaluator.py
+++ b/src/ai4gd_momconnect_haystack/evaluation/batch_evaluator.py
@@ -1,0 +1,211 @@
+# Save this as batch_evaluator_final.py
+import logging
+import json
+from pathlib import Path
+from langfuse import Langfuse
+
+# --- Setup ---
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+def load_golden_dataset(path: Path) -> list:
+    """Loads the golden dataset from a JSON file."""
+    try:
+        with open(path, 'r') as f:
+            return json.load(f)
+    except Exception as e:
+        logger.error(f"Failed to load golden dataset from {path}: {e}")
+        return []
+
+
+def run_batch_evaluation(scenarios_to_evaluate: list) -> None:
+    """
+    Performs a final, robust turn-by-turn evaluation.
+    This script is updated to align with the final ground truth schema.
+    """
+    logging.info("--- Starting Final Batch Evaluation Script ---")
+    langfuse = Langfuse()
+
+    if not scenarios_to_evaluate:
+        return
+
+    for scenario in scenarios_to_evaluate:
+        session_id_from_file = scenario.get("scenario_id")
+        flow_type = scenario.get("flow_type")
+        ground_truth_turns = scenario.get("turns", [])
+        if not session_id_from_file or not flow_type:
+            continue
+
+        #_____ StopIteration
+        latest_session_id = None
+        if not session_id_from_file or not flow_type:
+            continue
+
+        session_id_to_evaluate = None
+
+        # --- NEW: Logic to handle the "LATEST" keyword ---
+        if session_id_from_file == "LATEST":
+            if latest_session_id is None:  # Fetch only if we haven't already
+                logger.info("'LATEST' keyword found. Fetching most recent session...")
+                try:
+                    latest_sessions = langfuse.get_sessions(limit=1)
+                    if latest_sessions:
+                        latest_session_id = latest_sessions[0].id
+                        logger.info(f"    ...found latest session: {latest_session_id}")
+                    else:
+                        logger.warning("Could not find any sessions in the project to evaluate.")
+                        continue # Skip this scenario
+                except Exception as e:
+                    logger.error(f"An error occurred while fetching the latest session: {e}")
+                    continue # Skip this scenario
+            session_id_to_evaluate = latest_session_id
+        else:
+            # If it's not "LATEST", use the ID from the file as usual
+            session_id_to_evaluate = session_id_from_file
+
+        if not session_id_to_evaluate:
+            continue
+
+
+        logger.info(f"\n>>> Evaluating Session: {session_id_to_evaluate} (Flow: {flow_type}) <<<")
+
+        try:
+            session = langfuse.get_session(session_id_to_evaluate)
+            traces_map = {trace.name: trace for trace in session.traces}
+        except Exception:
+            logger.warning(f"Session '{session_id_to_evaluate}' not found in Langfuse. Skipping.")
+            continue
+
+        for turn in ground_truth_turns:
+            flow_type = turn.get("flow_type")
+            q_num = turn.get("question_number")
+            user_utterance = turn.get("user_utterance")
+            ground_truth_delta = turn.get("ground_truth_delta")
+            
+            # Add a safety check
+            if not flow_type or q_num is None or ground_truth_delta is None:
+                continue
+
+            # Construct the expected trace name using the turn's specific flow_type
+            expected_trace_name = f"{flow_type}-q{q_num}"
+            actual_trace = traces_map.get(expected_trace_name)
+            
+            if not actual_trace:
+                logger.warning(f"    Trace '{expected_trace_name}' not found. Skipping.")
+                continue
+
+            logger.info(f"  - Scoring trace: '{actual_trace.name}' (ID: {actual_trace.id})")
+            
+            actual_output = actual_trace.output
+            is_match = (actual_output == ground_truth_delta)
+            score_value = 1 if is_match else 0
+            comment = (f"SUCCESS: Match." if is_match
+                       else f"FAILURE on user utterance: '{user_utterance}'. Expected {ground_truth_delta}, but got {actual_output}")
+
+            score_name = f"{flow_type}_accuracy"
+
+            langfuse.score(
+                trace_id=actual_trace.id,
+                name=score_name,
+                value=score_value,
+                comment=comment
+            )
+            logger.info(f"    Applied score '{score_name}' with value {score_value}.")
+
+
+    logging.info("\n--- Batch Evaluation Finished ---")
+    langfuse.flush()
+    langfuse.shutdown()
+
+
+if __name__ == "__main__":
+    # Point this to the actual path of your final golden dataset
+    SCRIPT_DIRECTORY = Path(__file__).resolve().parent
+    DATASET_PATH = SCRIPT_DIRECTORY / "evaluation" / "data" / "golden_dataset.json"
+    if not DATASET_PATH.exists():
+        logger.error(
+            f"CRITICAL: Golden dataset not found at expected path: {DATASET_PATH}"
+        )
+        logger.error("Please ensure the 'evaluation' directory is in the same directory as the batch_evaluator.py script.")
+        scenarios_to_evaluate = [
+            {
+                "scenario_id": "full_session_amahle_001",
+                "description": "A complete, hybrid evaluation for Amahle (Persona 7), a university student from KZN, who answers some questions conversationally.",
+                "notes_for_human_review": "Verify the model can extract multiple data points from a single utterance (turn 3). Check how the assessment handles a direct refusal to answer (turn 6).",
+
+                # The user_persona provides rich context for the test case.
+                "user_persona": {
+                "id": "user_persona_07",
+                "age": 21,
+                "details": {
+                    "location_description": "Durban, KwaZulu-Natal",
+                    "relationship_status_persona": "In a relationship",
+                    "education_level_persona": "Currently at university",
+                    "num_children_persona": 0
+                }
+                },
+
+                # A single 'turns' array containing the entire, ordered conversation.
+                "turns": [
+                {
+                    "flow_type": "onboarding",
+                    "question_number": 1,
+                    "llm_utterance": "Welcome! To get started, which province do you currently reside in? 🏞️",
+                    "user_utterance": "Hi, I live in KZN.",
+                    "ground_truth_delta": { "province": "KwaZulu-Natal" }
+                },
+                {
+                    "flow_type": "onboarding",
+                    "question_number": 4,
+                    "llm_utterance": "Thanks! What is your highest level of education? 📚",
+                    "user_utterance": "I finished my matric last year, now I'm at uni.",
+                    "ground_truth_delta": { "education_level": "More than high school" }
+                },
+                {
+                    "flow_type": "onboarding",
+                    "question_number": 3,
+                    "llm_utterance": "Okay, great. What is your current relationship status? 👤",
+                    "user_utterance": "I'm in a relationship and I don't have any kids yet.",
+                    "ground_truth_delta": {
+                        "relationship_status": "In a relationship",
+                        "num_children": "0"
+                    }
+                },
+                {
+                    "flow_type": "assessment",
+                    "question_number": 1,
+                    "llm_utterance": "How confident are you in making decisions about your health?",
+                    "user_utterance": "Very! A 5 for sure.",
+                    "ground_truth_delta": {
+                        "processed_user_response": "Very confident",
+                        "current_assessment_step": 1
+                    }
+                },
+                {
+                    "flow_type": "assessment",
+                    "question_number": 2,
+                    "llm_utterance": "How confident are you discussing medical problems with your doctor or nurse?",
+                    "user_utterance": "Uhm, maybe a 3?",
+                    "ground_truth_delta": {
+                        "processed_user_response": "Somewhat confident",
+                        "current_assessment_step": 2
+                    }
+                },
+                {
+                    "flow_type": "assessment",
+                    "question_number": 3,
+                    "llm_utterance": "I feel confident questioning my healthcare provider about my treatment.",
+                    "user_utterance": "I'd rather not say for that one.",
+                    "ground_truth_delta": {
+                        "processed_user_response": "skipped",
+                        "current_assessment_step": 3
+                    }
+                }
+                ]
+            },
+        ]
+    else:
+        scenarios_to_evaluate = load_golden_dataset(DATASET_PATH)
+
+    run_batch_evaluation(scenarios_to_evaluate)
+    logger.info("Batch evaluation script completed successfully.")

--- a/src/ai4gd_momconnect_haystack/evaluation/data/golden_dataset.json
+++ b/src/ai4gd_momconnect_haystack/evaluation/data/golden_dataset.json
@@ -1,0 +1,85 @@
+[
+    {
+      "scenario_id": "LATEST",
+      "flow_type": "onboarding",
+      "description": "A rich, hybrid evaluation for Naledi (Persona 6), an anxious 19-year-old from a farm in North West, seeking guidance.",
+      "notes_for_human_review": "Check if the model's tone is supportive. Verify that 'grade 9' is correctly normalized to 'Some high school'.",
+      "user_persona": {
+        "id": "user_persona_06"
+      },
+      "turns": [
+        {
+          "question_number": 1,
+          "llm_utterance": "Which province do you currently reside in? 🏞️",
+          "user_utterance": "I live on a farm out in the North West.",
+          "ground_truth_delta": { "province": "North West" }
+        },
+        {
+          "question_number": 4,
+          "llm_utterance": "What level of education have you completed or are currently pursuing? 📚",
+          "user_utterance": "I only finished Grade 9 at school.",
+          "ground_truth_delta": { "education_level": "Some high school" }
+        },
+        {
+          "question_number": 6,
+          "llm_utterance": "How many children do you have, if any? Please count all your children of any age. 👶🏽",
+          "user_utterance": "I have one little one already.",
+          "ground_truth_delta": { "num_children": "1" }
+        }
+      ],
+      "expected_end_state": {
+        "province": "North West",
+        "area_type": "Farm or smallholding",
+        "relationship_status": "Single",
+        "education_level": "Some high school",
+        "hunger_days": "3-4 days",
+        "num_children": "1",
+        "phone_ownership": "No"
+      }
+    },
+    {
+      "scenario_id": "interactive-session-2025-06-09T04%3A05%3A27.360781",
+      "flow_type": "assessment",
+      "description": "An assessment for Naledi (Persona 6), testing how the system handles conversational answers to scaled questions.",
+      "notes_for_human_review": "Check how the model handles 'I guess a 4' and 'I don't know'. The validation should correctly map these to 'Confident' and 'skipped' respectively.",
+      "user_persona": {
+        "id": "user_persona_06"
+      },
+      "turns": [
+        {
+          "question_number": 1,
+          "llm_utterance": "How confident are you in making decisions about your health, especially as a single mother?",
+          "user_utterance": "I guess I'm pretty confident, so a 4.",
+          "ground_truth_delta": {
+              "processed_user_response": "Confident",
+              "current_assessment_step": 2
+          }
+        },
+        {
+          "question_number": 2,
+          "llm_utterance": "How confident are you discussing your medical problems with your healthcare provider, such as a doctor or nurse?",
+          "user_utterance": "Only a little bit, maybe a 2",
+          "ground_truth_delta": {
+              "processed_user_response": "A little confident",
+              "current_assessment_step": 3
+          }
+        },
+        {
+          "question_number": 3,
+          "llm_utterance": "I feel confident questioning my healthcare provider about my treatment.",
+          "user_utterance": "I don't know about that one.",
+          "ground_truth_delta": {
+              "processed_user_response": "skipped",
+              "current_assessment_step": 4
+          }
+        }
+      ],
+      "expected_end_state": {
+         "assessment_results": {
+             "1": "Confident",
+             "2": "A little confident",
+             "3": "skipped"
+         }
+      }
+    }
+  ]

--- a/src/ai4gd_momconnect_haystack/main.py
+++ b/src/ai4gd_momconnect_haystack/main.py
@@ -1,6 +1,8 @@
 import logging
-
+import datetime
+import copy
 from . import tasks
+from langfuse import Langfuse
 
 
 logger = logging.getLogger(__name__)
@@ -11,8 +13,14 @@ logger = logging.getLogger(__name__)
 def run_simulation():
     """
     Runs a simulation of the onboarding and assessment process using the pipelines.
+    Then logs data to Langfuse using dynamic trace names
+    based on question numbers for robust, turn-by-turn evaluation.
     """
-    logger.info("--- Starting Haystack POC Simulation ---")
+    # --- LANGFUSE: Initialize the client ---
+    langfuse = Langfuse()
+    session_id = f"interactive-session-{datetime.datetime.now().isoformat()}"
+    
+    logger.info("--- Starting Haystack POC Simulation  (Session: {session_id}) ---")
 
     # --- Simulation ---
     # ** Onboarding Scenario **
@@ -38,22 +46,67 @@ def run_simulation():
         print("-" * 20)
         logger.info(f"Onboarding Question Attempt: {attempt + 1}")
 
-        ### Endpoint 1: Turn can call to get the next question to send to a user.
-        contextualized_question = tasks.get_next_onboarding_question(
+        # --- UPDATED LOGIC 1: Handle the dictionary returned by the task ---
+        # We now expect a dictionary containing the question and its number.
+        question_data = tasks.get_next_onboarding_question(
             user_context, chat_history
         )
-        if not contextualized_question:
-            logger.info("Onboarding flow complete.")
+
+        # Add a robust check in case the task returns None or an incomplete dictionary.
+        if not question_data or not question_data.get("question_number"):
+            logger.info("Onboarding flow complete or invalid data returned from task.")
             break
 
+        # Unpack the dictionary into the variables we need.
+        contextualized_question = question_data.get("question", "Error: No question text found.")
+        question_number = question_data.get("question_number")
+
+        # --- UPDATED LOGIC 2: Create the trace with the dynamic name ---
+        context_before = copy.deepcopy(user_context)
+        trace = langfuse.trace(
+            name=f"onboarding-q{question_number}",
+            session_id=session_id,
+            metadata={"initial_context": context_before}
+        )
+
         # Simulate User Response & Data Extraction
-        chat_history.append("System to User: " + contextualized_question + "\n> ")
+        chat_history.append({"role": "system", "content": contextualized_question})
         user_response = input(contextualized_question + "\n> ")
-        chat_history.append("User to System: " + user_response + "\n> ")
+        chat_history.append({"role": "user", "content": user_response})
+
+        # --- LANGFUSE: Update trace ---
+        trace.update(
+            input={
+                "question": contextualized_question,
+                "user_response": user_response
+            }
+        )
 
         ### Endpoint 2: Turn can call to get extracted data from a user response.
+        # --- LANGFUSE: Create a "generation" for the LLM extraction step ---
+        generation_extract = trace.generation(
+            name="extract-onboarding-data",
+            input=user_response,
+            model="your-extraction-model",  # IMPORTANT: Replace with your actual model name
+        )
+
         user_context = tasks.extract_onboarding_data_from_response(
             user_response, user_context, chat_history
+        )
+        # --- LANGFUSE: Find what was newly extracted and log it as the output ---
+        newly_extracted_data = {
+            k: user_context[k] for k in user_context
+            if user_context.get(k) != context_before.get(k)
+        }
+        generation_extract.end(output={"extracted_data": newly_extracted_data})
+
+        # --- LANGFUSE: Update the trace's final output to be the new state ---
+        # The trace's final output is now the *delta* (what's new), plus the
+        # field that was being collected in this turn.
+        trace.update(
+            output={
+                **newly_extracted_data,  # Unpack the newly extracted data
+            }
         )
 
     # ** Assessment Scenario **
@@ -68,35 +121,76 @@ def run_simulation():
         print("-" * 20)
         logger.info(f"Assessment Step: Requesting step after {current_assessment_step}")
 
-        ### Endpoint 3: Turn can call to get an assessment question to send to the user.
-        result = tasks.get_assessment_question(
+        # --- UPDATED LOGIC 3: Apply the same dynamic naming to the assessment part ---
+        result_q = tasks.get_assessment_question(
             flow_id="dma_flow_id",
             question_number=current_assessment_step,
             current_assessment_step=current_assessment_step,
             user_context=user_context,
         )
-        if not result:
+
+        if not result_q or not result_q.get("current_question_number"):
             logger.info("Assessment flow complete.")
             break
-        contextualized_question = result["contextualized_question"]
-        current_assessment_step = result["current_question_number"]
+
+        # Unpack the results
+        contextualized_question = result_q["contextualized_question"]
+        question_number = result_q["current_question_number"] # This is the step number
+
+
+        # --- LANGFUSE: Capture the "before" state for the assessment turn ---
+        # --- LANGFUSE: Create a trace for the assessment turn ---
+        context_before = copy.deepcopy(user_context)
+        trace = langfuse.trace(
+            name=f"assessment-q{question_number}",
+            session_id=session_id,
+            metadata={"initial_context": context_before}
+        )
+
+        ### Endpoint 3: Turn can call to get an assessment question to send to the user.
+        # --- LANGFUSE: Create a "span" for this step ---
+        trace.span(name="get-assessment-question", output=result_q)
 
         # Simulate User Response
         user_response = input(contextualized_question + "\n> ")
 
-        ### Endpoint 4: Turn can call to validate a user's response to an assessment question.
-        result = tasks.validate_assessment_answer(
-            user_response, current_assessment_step
+        # --- LANGFUSE: Update trace with user input and bot question ---
+        trace.update(
+            input={
+                "question": contextualized_question,
+                "user_response": user_response
+            }
         )
-        if not result:
+
+        ### Endpoint 4: Turn can call to validate a user's response to an assessment question.
+        # --- LANGFUSE: Create a "generation" for the LLM validation step ---
+        generation_validate = trace.generation(
+            name="validate-assessment-answer",
+            input=user_response,
+            model="your-validation-model"  # IMPORTANT: Replace with your model name
+        )
+
+        result_v = tasks.validate_assessment_answer(
+            user_response, question_number
+        )
+        # --- LANGFUSE: Log the output of the generation ---
+        # --- LANGFUSE: Update trace with the final result ---
+        generation_validate.end(output=result_v)
+        trace.update(output=result_v)
+
+        if not result_v:
             logger.warning(
-                f"Response validation failed for step {current_assessment_step}."
+                f"Response validation failed for step {question_number}."
             )
             continue
         # processed_user_response = result['processed_user_response']
-        current_assessment_step = result["current_assessment_step"]
+        current_assessment_step = result_v["current_assessment_step"]
 
     logger.info("--- Simulation Complete ---")
+    # --- LANGFUSE: Ensure all buffered data is sent to the server before the script exits ---
+    langfuse.flush()
+    langfuse.shutdown()
+    print("All trace data flushed to Langfuse.")
 
 
 def main():

--- a/src/ai4gd_momconnect_haystack/tasks.py
+++ b/src/ai4gd_momconnect_haystack/tasks.py
@@ -61,8 +61,8 @@ def get_next_onboarding_question(user_context: dict, chat_history: list) -> str 
 
     return {
         "question": contextualized_question,
-        "question_number": chosen_question_number
-        }
+        "question_number": chosen_question_number,
+    }
 
 
 def extract_onboarding_data_from_response(

--- a/src/ai4gd_momconnect_haystack/tasks.py
+++ b/src/ai4gd_momconnect_haystack/tasks.py
@@ -15,7 +15,9 @@ all_onboarding_questions = doc_store.ONBOARDING_FLOW.get(onboarding_flow_id, [])
 all_dma_questions = doc_store.DMA_FLOW.get(dma_flow_id, [])
 
 
-def get_next_onboarding_question(user_context: dict, chat_history: list) -> dict[str, Any] | None:
+def get_next_onboarding_question(
+    user_context: dict, chat_history: list
+) -> dict[str, Any] | None:
     # Get remaining questions
     remaining_questions_list = doc_store.get_remaining_onboarding_questions(
         user_context, all_onboarding_questions

--- a/src/ai4gd_momconnect_haystack/tasks.py
+++ b/src/ai4gd_momconnect_haystack/tasks.py
@@ -59,7 +59,10 @@ def get_next_onboarding_question(user_context: dict, chat_history: list) -> str 
     else:
         logger.info(f"Original question was: '{current_step_data['content']}'")
 
-    return contextualized_question
+    return {
+        "question": contextualized_question,
+        "question_number": chosen_question_number
+        }
 
 
 def extract_onboarding_data_from_response(

--- a/src/ai4gd_momconnect_haystack/tasks.py
+++ b/src/ai4gd_momconnect_haystack/tasks.py
@@ -15,7 +15,7 @@ all_onboarding_questions = doc_store.ONBOARDING_FLOW.get(onboarding_flow_id, [])
 all_dma_questions = doc_store.DMA_FLOW.get(dma_flow_id, [])
 
 
-def get_next_onboarding_question(user_context: dict, chat_history: list) -> str | None:
+def get_next_onboarding_question(user_context: dict, chat_history: list) -> dict[str, Any] | None:
     # Get remaining questions
     remaining_questions_list = doc_store.get_remaining_onboarding_questions(
         user_context, all_onboarding_questions


### PR DESCRIPTION
### Running the Batch Evaluation Suite

This guide explains how to run the batch evaluation script (`batch_evaluator.py`) to score conversational traces that have been logged to Langfuse.

The script works by comparing the outputs of a recorded user session against a "golden dataset" (a curated set of correct answers) to calculate accuracy metrics on a turn-by-turn basis. The entire workflow is designed to be run within a Docker environment.

***

### Prerequisites

Before running the evaluation, ensure you have the following set up:

1.  **Docker and Docker Compose:** You must have both installed and running on your system.
2.  **Langfuse Credentials:** Your project's root directory must contain a `.env` file with your Langfuse API keys and host. Docker Compose will automatically load this file if configured correctly in `docker-compose.yml`.

    **.env**
    ```env
    LANGFUSE_PUBLIC_KEY="pk-lf-..."
    LANGFUSE_SECRET_KEY="sk-lf-..."
    LANGFUSE_HOST="[https://cloud.langfuse.com](https://cloud.langfuse.com)"
    ```

3.  **A Logged Session:** You must have already run the main application at least once to generate a session and its traces in Langfuse. You will need the `session_id` from this run.

4.  **A Golden Dataset File:** You must have a ground truth file. The script expects this file to be located at `src/ai4gd_momconnect_haystack/evaluations/data/golden_dataset.json`.

***

### Step-by-Step Workflow

#### Step 1: Generate a Session & Get its ID

Run the main interactive simulation **using Docker Compose** to generate a new session in Langfuse. The `session_id` will be printed to the console when the script starts.

```bash
docker-compose run --rm python-app uv run python -m src.ai4gd_momconnect_haystack.main