### PR TITLE
Add prometheus metrics endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "python-dotenv>=1.1.0",
     "fastapi[standard]>=0.115.12",
     "sentry-sdk[fastapi]>=2.29.1",
+    "prometheus-fastapi-instrumentator>=7.1.0",
 ]
 
 [dependency-groups]

--- a/src/ai4gd_momconnect_haystack/api.py
+++ b/src/ai4gd_momconnect_haystack/api.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any
 import sentry_sdk
 from dotenv import load_dotenv
 from fastapi import Depends, FastAPI, Header, HTTPException
+from prometheus_fastapi_instrumentator import Instrumentator
 from pydantic import BaseModel
 
 from .tasks import (
@@ -24,6 +25,8 @@ def setup_sentry():
 setup_sentry()
 
 app = FastAPI()
+
+Instrumentator().instrument(app).expose(app)
 
 
 @app.get("/health")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -117,3 +117,13 @@ def test_sentry_setup():
     setup_sentry()
     assert get_sentry_client().is_active()
     assert get_sentry_client().dsn == "https://testdsn@testdsn.example.org/12345"
+
+
+def test_prometheus_metrics():
+    """
+    Prometheus metrics are exposed on the /metrics endpoint
+    """
+    client = TestClient(app)
+    response = client.get("/metrics")
+    assert response.status_code == 200
+    assert "python_info" in response.text

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,7 @@ dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "haystack-ai" },
     { name = "openai" },
+    { name = "prometheus-fastapi-instrumentator" },
     { name = "python-dotenv" },
     { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "weaviate-haystack" },
@@ -32,6 +33,7 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.12" },
     { name = "haystack-ai", specifier = ">=2.13.2" },
     { name = "openai", specifier = ">=1.78.1" },
+    { name = "prometheus-fastapi-instrumentator", specifier = ">=7.1.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.29.1" },
     { name = "weaviate-haystack", specifier = ">=6.0.0" },
@@ -1419,6 +1421,28 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/85/a9/ec3bbc23b6f3c23c52e0b5795b1357cca74aa5cfb254213f1e471fef9b4d/posthog-3.25.0.tar.gz", hash = "sha256:9168f3e7a0a5571b6b1065c41b3c171fbc68bfe72c3ac0bfd6e3d2fcdb7df2ca", size = 75968, upload-time = "2025-04-15T21:15:45.552Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/e2/c158366e621562ef224f132e75c1d1c1fce6b078a19f7d8060451a12d4b9/posthog-3.25.0-py2.py3-none-any.whl", hash = "sha256:85db78c13d1ecb11aed06fad53759c4e8fb3633442c2f3d0336bc0ce8a585d30", size = 89115, upload-time = "2025-04-15T21:15:43.934Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/cf/40dde0a2be27cc1eb41e333d1a674a74ce8b8b0457269cc640fd42b07cf7/prometheus_client-0.22.1.tar.gz", hash = "sha256:190f1331e783cf21eb60bca559354e0a4d4378facecf78f5428c39b675d20d28", size = 69746, upload-time = "2025-06-02T14:29:01.152Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/ae/ec06af4fe3ee72d16973474f122541746196aaa16cea6f66d18b963c6177/prometheus_client-0.22.1-py3-none-any.whl", hash = "sha256:cca895342e308174341b2cbf99a56bef291fbc0ef7b9e5412a0f26d653ba7094", size = 58694, upload-time = "2025-06-02T14:29:00.068Z" },
+]
+
+[[package]]
+name = "prometheus-fastapi-instrumentator"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prometheus-client" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/6d/24d53033cf93826aa7857699a4450c1c67e5b9c710e925b1ed2b320c04df/prometheus_fastapi_instrumentator-7.1.0.tar.gz", hash = "sha256:be7cd61eeea4e5912aeccb4261c6631b3f227d8924542d79eaf5af3f439cbe5e", size = 20220, upload-time = "2025-03-19T19:35:05.351Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/72/0824c18f3bc75810f55dacc2dd933f6ec829771180245ae3cc976195dec0/prometheus_fastapi_instrumentator-7.1.0-py3-none-any.whl", hash = "sha256:978130f3c0bb7b8ebcc90d35516a6fe13e02d2eb358c8f83887cdef7020c31e9", size = 19296, upload-time = "2025-03-19T19:35:04.323Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add a prometheus metrics endpoint that is instrumented for FastAPI, so that we can get metrics on our API
