### PR TITLE
Remove TODO from health endpoint

### DIFF
--- a/src/ai4gd_momconnect_haystack/api.py
+++ b/src/ai4gd_momconnect_haystack/api.py
@@ -31,7 +31,6 @@ Instrumentator().instrument(app).expose(app)
 
 @app.get("/health")
 def health():
-    # TODO: Proper health check
     return {"health": "ok"}
 
 


### PR DESCRIPTION
I went down the rabbithole of the health endpoint. To accurately measure if our dependant services are working (document store, LLM), we need to make requests to them, but these requests cost money, so we also need to secure the endpoint. I don’t think it’s worth it using a bunch of our LLM tokens to constantly check if the service is up, because if it’s not up, there’s nothing we can do. The only thing it buys us is if there’s a sudden configuration error (token expires or is deleted), then we’ll know about it without anyone interacting with the service first. But either way, I think it’s too dangerous to have a health endpoint that constantly costs us LLM tokens, so I’m leaving the health endpoint as is (just that the service is able to respond to HTTP requests)
