### PR TITLE
Assessment score mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,4 @@ weaviate_data/
 evaluation_outputs/
 .deepeval/
 .vscode/
+src/ai4gd_momconnect_haystack/run_output/

--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,4 @@ weaviate_data/
 .python-version
 evaluation_outputs/
 .deepeval/
+.vscode/

--- a/src/ai4gd_momconnect_haystack/doc_store.py
+++ b/src/ai4gd_momconnect_haystack/doc_store.py
@@ -32,6 +32,7 @@ ONBOARDING_FLOW = read_json(data_dir / "onboarding.json")
 
 # Assessment Questions Data
 DMA_FLOW = read_json(data_dir / "dma.json")
+KAB_FLOW = read_json(data_dir / "kab.json")
 
 
 # --- Core Functions ---
@@ -173,6 +174,7 @@ def setup_document_store() -> WeaviateDocumentStore:
         ingest_content(indexing_pipe, ONBOARDING_FLOW)
         logger.info("--- Ingesting Assessment Content ---")
         ingest_content(indexing_pipe, DMA_FLOW)
+        ingest_content(indexing_pipe, KAB_FLOW)
     else:
         logger.info(
             "Documents found in the store. Skipping ingestion to avoid duplicates."

--- a/src/ai4gd_momconnect_haystack/evaluation/data/evaluation_results_20250616.txt
+++ b/src/ai4gd_momconnect_haystack/evaluation/data/evaluation_results_20250616.txt
@@ -1,0 +1,939 @@
+
+--- Running Per-Turn Evaluations (this may take a moment) ---
+✨ You're running DeepEval's latest Answer Relevancy Metric! (using gpt-4o, 
+strict=False, async_mode=True)...
+
+
+======================================================================
+
+Metrics Summary
+
+  - ✅ Answer Relevancy (score: 1.0, threshold: 0.7, strict: False, evaluation model: gpt-4o, reason: The score is 1.00 because the response perfectly addresses the question without any irrelevant information, maintaining complete focus on the input query. Great job!, error: None)
+
+For test case:
+
+  - input: Which province do you live in?
+  - actual output: Which province do you currently live in? We just need this information to complete your profile. 🏞️
+  - expected output: None
+  - context: None
+  - retrieval context: None
+
+======================================================================
+
+Overall Metric Pass Rates
+
+Answer Relevancy: 100.00% pass rate
+
+======================================================================
+
+
+✓ Tests finished 🎉! Run 'deepeval view' to analyze, debug, and save evaluation 
+results on Confident AI.
+
+✨ You're running DeepEval's latest Answer Relevancy Metric! (using gpt-4o, 
+strict=False, async_mode=True)...
+
+
+======================================================================
+
+Metrics Summary
+
+  - ❌ Answer Relevancy (score: 0.5, threshold: 0.7, strict: False, evaluation model: gpt-4o, reason: The score is 0.50 because the response provided a type of residence instead of specifying a province, which is crucial to fully address the input question. However, the response still partially relates to the topic of residence, maintaining some relevance., error: None)
+
+For test case:
+
+  - input: Which province do you currently live in? We just need this information to complete your profile. 🏞️
+  - actual output: I live on a farm out in the North West.
+  - expected output: None
+  - context: None
+  - retrieval context: None
+
+======================================================================
+
+Overall Metric Pass Rates
+
+Answer Relevancy: 0.00% pass rate
+
+======================================================================
+
+
+✓ Tests finished 🎉! Run 'deepeval view' to analyze, debug, and save evaluation 
+results on Confident AI.
+
+✨ You're running DeepEval's latest Answer Relevancy Metric! (using gpt-4o, 
+strict=False, async_mode=True)...
+
+
+======================================================================
+
+Metrics Summary
+
+  - ❌ Answer Relevancy (score: 0.0, threshold: 0.7, strict: False, evaluation model: gpt-4o, reason: The score is 0.00 because the output did not address the question about the type of area someone lives in. Instead, it included irrelevant information about location and the purpose of collecting information, which did not pertain to the input question., error: None)
+
+For test case:
+
+  - input: What kind of area do you live in? 🏘️
+  - actual output: Which province do you currently live in? We just need this information to complete your profile. 🏞️
+  - expected output: None
+  - context: None
+  - retrieval context: None
+
+======================================================================
+
+Overall Metric Pass Rates
+
+Answer Relevancy: 0.00% pass rate
+
+======================================================================
+
+
+✓ Tests finished 🎉! Run 'deepeval view' to analyze, debug, and save evaluation 
+results on Confident AI.
+
+✨ You're running DeepEval's latest Answer Relevancy Metric! (using gpt-4o, 
+strict=False, async_mode=True)...
+
+
+======================================================================
+
+Metrics Summary
+
+  - ❌ Answer Relevancy (score: 0.0, threshold: 0.7, strict: False, evaluation model: gpt-4o, reason: The score is 0.00 because the response did not address the question about the province of residence, instead mentioning living on a farm without specifying the location. This lack of relevant information resulted in a score of zero., error: None)
+
+For test case:
+
+  - input: Which province do you currently live in? We just need this information to complete your profile. 🏞️
+  - actual output: I live on a farm.
+  - expected output: None
+  - context: None
+  - retrieval context: None
+
+======================================================================
+
+Overall Metric Pass Rates
+
+Answer Relevancy: 0.00% pass rate
+
+======================================================================
+
+
+✓ Tests finished 🎉! Run 'deepeval view' to analyze, debug, and save evaluation 
+results on Confident AI.
+
+✨ You're running DeepEval's latest Answer Relevancy Metric! (using gpt-4o, 
+strict=False, async_mode=True)...
+
+
+======================================================================
+
+Metrics Summary
+
+  - ✅ Answer Relevancy (score: 1.0, threshold: 0.7, strict: False, evaluation model: gpt-4o, reason: The score is 1.00 because the response perfectly addresses the input without any irrelevant statements, maintaining a clear and focused answer. Great job!, error: None)
+
+For test case:
+
+  - input: What’s your current relationship status? 👤
+  - actual output: What's your current relationship status? Are you single, in a relationship, married, or would you like to skip this question?
+  - expected output: None
+  - context: None
+  - retrieval context: None
+
+======================================================================
+
+Overall Metric Pass Rates
+
+Answer Relevancy: 100.00% pass rate
+
+======================================================================
+
+
+✓ Tests finished 🎉! Run 'deepeval view' to analyze, debug, and save evaluation 
+results on Confident AI.
+
+✨ You're running DeepEval's latest Answer Relevancy Metric! (using gpt-4o, 
+strict=False, async_mode=True)...
+
+
+======================================================================
+
+Metrics Summary
+
+  - ✅ Answer Relevancy (score: 1.0, threshold: 0.7, strict: False, evaluation model: gpt-4o, reason: The score is 1.00 because the response perfectly addressed the input without any irrelevant statements. Great job on staying focused and relevant!, error: None)
+
+For test case:
+
+  - input: What's your current relationship status? Are you single, in a relationship, married, or would you like to skip this question?
+  - actual output: I am single.
+  - expected output: None
+  - context: None
+  - retrieval context: None
+
+======================================================================
+
+Overall Metric Pass Rates
+
+Answer Relevancy: 100.00% pass rate
+
+======================================================================
+
+
+✓ Tests finished 🎉! Run 'deepeval view' to analyze, debug, and save evaluation 
+results on Confident AI.
+
+✨ You're running DeepEval's latest Answer Relevancy Metric! (using gpt-4o, 
+strict=False, async_mode=True)...
+
+
+======================================================================
+
+Metrics Summary
+
+  - ✅ Answer Relevancy (score: 1.0, threshold: 0.7, strict: False, evaluation model: gpt-4o, reason: The score is 1.00 because the response perfectly addresses the question without any irrelevant information, maintaining a clear and focused answer. Great job!, error: None)
+
+For test case:
+
+  - input: What’s your highest level of education? 📚
+  - actual output: What is the highest level of education you have completed so far? 📚 We want to make sure your profile is complete.
+  - expected output: None
+  - context: None
+  - retrieval context: None
+
+======================================================================
+
+Overall Metric Pass Rates
+
+Answer Relevancy: 100.00% pass rate
+
+======================================================================
+
+
+✓ Tests finished 🎉! Run 'deepeval view' to analyze, debug, and save evaluation 
+results on Confident AI.
+
+✨ You're running DeepEval's latest Answer Relevancy Metric! (using gpt-4o, 
+strict=False, async_mode=True)...
+
+
+======================================================================
+
+Metrics Summary
+
+  - ✅ Answer Relevancy (score: 1.0, threshold: 0.7, strict: False, evaluation model: gpt-4o, reason: The score is 1.00 because the response is perfectly relevant and directly addresses the input question without any irrelevant statements. Great job on maintaining focus and clarity!, error: None)
+
+For test case:
+
+  - input: What is the highest level of education you have completed so far? 📚 We want to make sure your profile is complete.
+  - actual output: I only finished Grade 9 at school.
+  - expected output: None
+  - context: None
+  - retrieval context: None
+
+======================================================================
+
+Overall Metric Pass Rates
+
+Answer Relevancy: 100.00% pass rate
+
+======================================================================
+
+
+✓ Tests finished 🎉! Run 'deepeval view' to analyze, debug, and save evaluation 
+results on Confident AI.
+
+✨ You're running DeepEval's latest Answer Relevancy Metric! (using gpt-4o, 
+strict=False, async_mode=True)...
+
+
+======================================================================
+
+Metrics Summary
+
+  - ✅ Answer Relevancy (score: 1.0, threshold: 0.7, strict: False, evaluation model: gpt-4o, reason: The score is 1.00 because the response was perfectly relevant, directly addressing the input without any irrelevant statements. Great job maintaining focus and clarity!, error: None)
+
+For test case:
+
+  - input: In the last week, how many days did you miss a meal because there wasn’t money for food? 🍞
+  - actual output: Have you had to skip meals in the last week due to lack of money for food? 🍞
+  - expected output: None
+  - context: None
+  - retrieval context: None
+
+======================================================================
+
+Overall Metric Pass Rates
+
+Answer Relevancy: 100.00% pass rate
+
+======================================================================
+
+
+✓ Tests finished 🎉! Run 'deepeval view' to analyze, debug, and save evaluation 
+results on Confident AI.
+
+✨ You're running DeepEval's latest Answer Relevancy Metric! (using gpt-4o, 
+strict=False, async_mode=True)...
+
+
+======================================================================
+
+Metrics Summary
+
+  - ✅ Answer Relevancy (score: 1.0, threshold: 0.7, strict: False, evaluation model: gpt-4o, reason: The score is 1.00 because the response is perfectly relevant and directly addresses the input question without any irrelevant statements. Great job!, error: None)
+
+For test case:
+
+  - input: Have you had to skip meals in the last week due to lack of money for food? 🍞
+  - actual output: I sometimes go without food, maybe 3-4 days.
+  - expected output: None
+  - context: None
+  - retrieval context: None
+
+======================================================================
+
+Overall Metric Pass Rates
+
+Answer Relevancy: 100.00% pass rate
+
+======================================================================
+
+
+✓ Tests finished 🎉! Run 'deepeval view' to analyze, debug, and save evaluation 
+results on Confident AI.
+
+✨ You're running DeepEval's latest Answer Relevancy Metric! (using gpt-4o, 
+strict=False, async_mode=True)...
+
+
+======================================================================
+
+Metrics Summary
+
+  - ✅ Answer Relevancy (score: 1.0, threshold: 0.7, strict: False, evaluation model: gpt-4o, reason: The score is 1.00 because the response perfectly addresses the input without any irrelevant statements, maintaining complete focus on the question asked. Great job!, error: None)
+
+For test case:
+
+  - input: How many children do you have? Count all your children of any age. 👶🏽
+  - actual output: How many children do you have, if any? We want to ensure we have all the details for your profile. 👶🏽
+  - expected output: None
+  - context: None
+  - retrieval context: None
+
+======================================================================
+
+Overall Metric Pass Rates
+
+Answer Relevancy: 100.00% pass rate
+
+======================================================================
+
+
+✓ Tests finished 🎉! Run 'deepeval view' to analyze, debug, and save evaluation 
+results on Confident AI.
+
+✨ You're running DeepEval's latest Answer Relevancy Metric! (using gpt-4o, 
+strict=False, async_mode=True)...
+
+
+======================================================================
+
+Metrics Summary
+
+  - ✅ Answer Relevancy (score: 1.0, threshold: 0.7, strict: False, evaluation model: gpt-4o, reason: The score is 1.00 because the response perfectly addresses the input without any irrelevant statements, ensuring all necessary details are captured for the profile. Great job!, error: None)
+
+For test case:
+
+  - input: How many children do you have, if any? We want to ensure we have all the details for your profile. 👶🏽
+  - actual output: I have one little one already.
+  - expected output: None
+  - context: None
+  - retrieval context: None
+
+======================================================================
+
+Overall Metric Pass Rates
+
+Answer Relevancy: 100.00% pass rate
+
+======================================================================
+
+
+✓ Tests finished 🎉! Run 'deepeval view' to analyze, debug, and save evaluation 
+results on Confident AI.
+
+✨ You're running DeepEval's latest Answer Relevancy Metric! (using gpt-4o, 
+strict=False, async_mode=True)...
+
+
+======================================================================
+
+Metrics Summary
+
+  - ❌ Answer Relevancy (score: 0.6666666666666666, threshold: 0.7, strict: False, evaluation model: gpt-4o, reason: The score is 0.67 because the response partially addresses the question about phone ownership, but includes an irrelevant statement about completing the onboarding process, which detracts from the overall relevancy., error: None)
+
+For test case:
+
+  - input: Do you own the phone you’re using right now? 📱
+  - actual output: Do you currently own the phone you're using to complete the onboarding process? 📱
+  - expected output: None
+  - context: None
+  - retrieval context: None
+
+======================================================================
+
+Overall Metric Pass Rates
+
+Answer Relevancy: 0.00% pass rate
+
+======================================================================
+
+
+✓ Tests finished 🎉! Run 'deepeval view' to analyze, debug, and save evaluation 
+results on Confident AI.
+
+✨ You're running DeepEval's latest Answer Relevancy Metric! (using gpt-4o, 
+strict=False, async_mode=True)...
+
+
+======================================================================
+
+Metrics Summary
+
+  - ✅ Answer Relevancy (score: 1.0, threshold: 0.7, strict: False, evaluation model: gpt-4o, reason: The score is 1.00 because the response is perfectly relevant to the input question, with no irrelevant statements present. Great job on staying focused and on point!, error: None)
+
+For test case:
+
+  - input: Do you currently own the phone you're using to complete the onboarding process? 📱
+  - actual output: No, I don't own this phone.
+  - expected output: None
+  - context: None
+  - retrieval context: None
+
+======================================================================
+
+Overall Metric Pass Rates
+
+Answer Relevancy: 100.00% pass rate
+
+======================================================================
+
+
+✓ Tests finished 🎉! Run 'deepeval view' to analyze, debug, and save evaluation 
+results on Confident AI.
+
+✨ You're running DeepEval's latest Answer Relevancy Metric! (using gpt-4o, 
+strict=False, async_mode=True)...
+
+
+======================================================================
+
+Metrics Summary
+
+  - ❌ Answer Relevancy (score: 0.25, threshold: 0.7, strict: False, evaluation model: gpt-4o, reason: The score is 0.25 because the output included several irrelevant statements about confidence levels and living conditions, which did not address the input's request for agreement or disagreement with a health decision-making statement. However, the score is not lower because the output did attempt to engage with the topic of decision-making, albeit indirectly., error: None)
+
+For test case:
+
+  - input: Great! Your answers to these 5 quick questions can help us support you better.
+
+How much do you agree or disagree with this statement?
+
+**I feel like I can make decisions about my health.**
+
+Please reply with one of these options:
+• I strongly disagree
+• I disagree
+• I’m not sure
+• I agree
+• I strongly agree
+• Skip
+  - actual output: How confident are you in making decisions about your health, especially considering your current living situation on a farm or smallholding in the North West province?
+    
+    Valid Responses:
+    1 - Not at all confident
+    2 - A little confident
+    3 - Somewhat confident
+    4 - Confident
+    5 - Very confident
+  - expected output: None
+  - context: None
+  - retrieval context: None
+
+======================================================================
+
+Overall Metric Pass Rates
+
+Answer Relevancy: 0.00% pass rate
+
+======================================================================
+
+
+✓ Tests finished 🎉! Run 'deepeval view' to analyze, debug, and save evaluation 
+results on Confident AI.
+
+✨ You're running DeepEval's latest Answer Relevancy Metric! (using gpt-4o, 
+strict=False, async_mode=True)...
+
+
+======================================================================
+
+Metrics Summary
+
+  - ✅ Answer Relevancy (score: 1.0, threshold: 0.7, strict: False, evaluation model: gpt-4o, reason: The score is 1.00 because the response perfectly aligns with the input, addressing the question directly without any irrelevant information. Great job on staying focused and relevant!, error: None)
+
+For test case:
+
+  - input: How confident are you in making decisions about your health, especially considering your current living situation on a farm or smallholding in the North West province?
+    
+    Valid Responses:
+    1 - Not at all confident
+    2 - A little confident
+    3 - Somewhat confident
+    4 - Confident
+    5 - Very confident
+  - actual output: I strongly agree
+  - expected output: None
+  - context: None
+  - retrieval context: None
+
+======================================================================
+
+Overall Metric Pass Rates
+
+Answer Relevancy: 100.00% pass rate
+
+======================================================================
+
+
+✓ Tests finished 🎉! Run 'deepeval view' to analyze, debug, and save evaluation 
+results on Confident AI.
+
+✨ You're running DeepEval's latest Answer Relevancy Metric! (using gpt-4o, 
+strict=False, async_mode=True)...
+
+
+======================================================================
+
+Metrics Summary
+
+  - ❌ Answer Relevancy (score: 0.14285714285714285, threshold: 0.7, strict: False, evaluation model: gpt-4o, reason: The score is 0.14 because the output primarily focused on explaining response options rather than directly addressing the input statement about discussing health issues with a health worker. While the response options are relevant in a broader context, they do not directly answer the input question, leading to a lower relevancy score., error: None)
+
+For test case:
+
+  - input: Thanks. How about this one?
+
+**I feel like I can talk about my health issues with a health worker.**
+
+Please reply with one of these options:
+• I strongly disagree
+• I disagree
+• I’m not sure
+• I agree
+• I strongly agree
+• Skip
+  - actual output: How confident are you discussing your medical problems with your healthcare provider? 
+Valid Responses:
+1 - Not at all confident
+2 - A little confident
+3 - Somewhat confident
+4 - Confident
+5 - Very confident
+  - expected output: None
+  - context: None
+  - retrieval context: None
+
+======================================================================
+
+Overall Metric Pass Rates
+
+Answer Relevancy: 0.00% pass rate
+
+======================================================================
+
+
+✓ Tests finished 🎉! Run 'deepeval view' to analyze, debug, and save evaluation 
+results on Confident AI.
+
+✨ You're running DeepEval's latest Answer Relevancy Metric! (using gpt-4o, 
+strict=False, async_mode=True)...
+
+
+======================================================================
+
+Metrics Summary
+
+  - ❌ Answer Relevancy (score: 0.0, threshold: 0.7, strict: False, evaluation model: gpt-4o, reason: The score is 0.00 because the statement 'I strongly agree.' does not directly address the question about confidence levels in discussing medical problems with a healthcare provider. The response lacks any reference to the provided scale or the context of the question, making it entirely irrelevant., error: None)
+
+For test case:
+
+  - input: How confident are you discussing your medical problems with your healthcare provider? 
+Valid Responses:
+1 - Not at all confident
+2 - A little confident
+3 - Somewhat confident
+4 - Confident
+5 - Very confident
+  - actual output: I strongly agree
+  - expected output: None
+  - context: None
+  - retrieval context: None
+
+======================================================================
+
+Overall Metric Pass Rates
+
+Answer Relevancy: 0.00% pass rate
+
+======================================================================
+
+
+✓ Tests finished 🎉! Run 'deepeval view' to analyze, debug, and save evaluation 
+results on Confident AI.
+
+✨ You're running DeepEval's latest Answer Relevancy Metric! (using gpt-4o, 
+strict=False, async_mode=True)...
+
+
+======================================================================
+
+Metrics Summary
+
+  - ❌ Answer Relevancy (score: 0.14285714285714285, threshold: 0.7, strict: False, evaluation model: gpt-4o, reason: The score is 0.14 because the output primarily consists of response options that do not directly address the input question about agreement with a health worker. While the options are related to expressing confidence levels, they do not provide a direct answer to the input statement, resulting in a low relevancy score., error: None)
+
+For test case:
+
+  - input: Here’s the next one 👇🏽
+
+How much do you agree or disagree with this statement:
+
+**I feel that I can disagree with a health worker about my treatment plan.**
+
+Please reply with one of these options:
+• I strongly disagree
+• I disagree
+• I’m not sure
+• I agree
+• I strongly agree
+• Skip
+  - actual output: Do you feel confident questioning your healthcare provider about your treatment?
+    Valid Responses:
+    1 - Not at all confident
+    2 - A little confident
+    3 - Somewhat confident
+    4 - Confident
+    5 - Very confident
+  - expected output: None
+  - context: None
+  - retrieval context: None
+
+======================================================================
+
+Overall Metric Pass Rates
+
+Answer Relevancy: 0.00% pass rate
+
+======================================================================
+
+
+✓ Tests finished 🎉! Run 'deepeval view' to analyze, debug, and save evaluation 
+results on Confident AI.
+
+✨ You're running DeepEval's latest Answer Relevancy Metric! (using gpt-4o, 
+strict=False, async_mode=True)...
+
+
+======================================================================
+
+Metrics Summary
+
+  - ✅ Answer Relevancy (score: 1.0, threshold: 0.7, strict: False, evaluation model: gpt-4o, reason: The score is 1.00 because the response perfectly aligns with the input, addressing the question directly without any irrelevant information. Great job!, error: None)
+
+For test case:
+
+  - input: Do you feel confident questioning your healthcare provider about your treatment?
+    Valid Responses:
+    1 - Not at all confident
+    2 - A little confident
+    3 - Somewhat confident
+    4 - Confident
+    5 - Very confident
+  - actual output: I don't know about that one.
+  - expected output: None
+  - context: None
+  - retrieval context: None
+
+======================================================================
+
+Overall Metric Pass Rates
+
+Answer Relevancy: 100.00% pass rate
+
+======================================================================
+
+
+✓ Tests finished 🎉! Run 'deepeval view' to analyze, debug, and save evaluation 
+results on Confident AI.
+
+✨ You're running DeepEval's latest Answer Relevancy Metric! (using gpt-4o, 
+strict=False, async_mode=True)...
+
+
+======================================================================
+
+Metrics Summary
+
+  - ❌ Answer Relevancy (score: 0.25, threshold: 0.7, strict: False, evaluation model: gpt-4o, reason: The score is 0.25 because the response included multiple irrelevant statements, such as discussing living on a farm and confidence levels, which did not directly address the input's request for agreement or disagreement on health improvement. However, the score is not lower because there was some attempt to engage with the topic of health., error: None)
+
+For test case:
+
+  - input: Almost done! How much do you agree or disagree with this one:
+
+**I feel that I can do things to improve my health.**
+
+Please reply with one of these options:
+• I strongly disagree
+• I disagree
+• I’m not sure
+• I agree
+• I strongly agree
+• Skip
+  - actual output: How confident are you in taking actions to improve your health, considering your current living situation on a farm or smallholding in the North West province?
+    Valid Responses:
+    1 - Not at all confident
+    2 - A little confident
+    3 - Somewhat confident
+    4 - Confident
+    5 - Very confident
+  - expected output: None
+  - context: None
+  - retrieval context: None
+
+======================================================================
+
+Overall Metric Pass Rates
+
+Answer Relevancy: 0.00% pass rate
+
+======================================================================
+
+
+✓ Tests finished 🎉! Run 'deepeval view' to analyze, debug, and save evaluation 
+results on Confident AI.
+
+✨ You're running DeepEval's latest Answer Relevancy Metric! (using gpt-4o, 
+strict=False, async_mode=True)...
+
+
+======================================================================
+
+Metrics Summary
+
+  - ✅ Answer Relevancy (score: 1.0, threshold: 0.7, strict: False, evaluation model: gpt-4o, reason: The score is 1.00 because the response perfectly aligns with the input, addressing the question directly without any irrelevant information. Great job on staying focused and relevant!, error: None)
+
+For test case:
+
+  - input: How confident are you in taking actions to improve your health, considering your current living situation on a farm or smallholding in the North West province?
+    Valid Responses:
+    1 - Not at all confident
+    2 - A little confident
+    3 - Somewhat confident
+    4 - Confident
+    5 - Very confident
+  - actual output: I strongly agree
+  - expected output: None
+  - context: None
+  - retrieval context: None
+
+======================================================================
+
+Overall Metric Pass Rates
+
+Answer Relevancy: 100.00% pass rate
+
+======================================================================
+
+
+✓ Tests finished 🎉! Run 'deepeval view' to analyze, debug, and save evaluation 
+results on Confident AI.
+
+✨ You're running DeepEval's latest Answer Relevancy Metric! (using gpt-4o, 
+strict=False, async_mode=True)...
+
+
+======================================================================
+
+Metrics Summary
+
+  - ❌ Answer Relevancy (score: 0.125, threshold: 0.7, strict: False, evaluation model: gpt-4o, reason: The score is 0.12 because the response included several irrelevant statements that did not directly address the input's request for a specific agreement level. The inclusion of unrelated details about location, phone access, and various confidence levels detracted from the focus on the input's options, resulting in a lower score., error: None)
+
+For test case:
+
+  - input: Great, thanks ⭐
+
+Here's the last one:
+
+**I feel that I can find information about my health from other places, not just a health worker.**
+
+Please reply with one of these options:
+• I strongly disagree
+• I disagree
+• I’m not sure
+• I agree
+• I strongly agree
+• Skip
+  - actual output: How confident are you in finding information about your health problems from other sources, considering your location in North West and limited access to a phone?
+    Valid Responses:
+    1 - Not at all confident
+    2 - A little confident
+    3 - Somewhat confident
+    4 - Confident
+    5 - Very confident
+  - expected output: None
+  - context: None
+  - retrieval context: None
+
+======================================================================
+
+Overall Metric Pass Rates
+
+Answer Relevancy: 0.00% pass rate
+
+======================================================================
+
+
+✓ Tests finished 🎉! Run 'deepeval view' to analyze, debug, and save evaluation 
+results on Confident AI.
+
+✨ You're running DeepEval's latest Answer Relevancy Metric! (using gpt-4o, 
+strict=False, async_mode=True)...
+
+
+======================================================================
+
+Metrics Summary
+
+  - ✅ Answer Relevancy (score: 1.0, threshold: 0.7, strict: False, evaluation model: gpt-4o, reason: The score is 1.00 because the response perfectly aligns with the input, addressing the question directly without any irrelevant information. Great job on maintaining focus and clarity!, error: None)
+
+For test case:
+
+  - input: How confident are you in finding information about your health problems from other sources, considering your location in North West and limited access to a phone?
+    Valid Responses:
+    1 - Not at all confident
+    2 - A little confident
+    3 - Somewhat confident
+    4 - Confident
+    5 - Very confident
+  - actual output: I strongly agree
+  - expected output: None
+  - context: None
+  - retrieval context: None
+
+======================================================================
+
+Overall Metric Pass Rates
+
+Answer Relevancy: 100.00% pass rate
+
+======================================================================
+
+
+✓ Tests finished 🎉! Run 'deepeval view' to analyze, debug, and save evaluation 
+results on Confident AI.
+
+
+
+==================================================
+              DETAILED TURN-BY-TURN REPORT
+==================================================
+
+--- [1mTurn: onboarding_user_123_250616-0635 (onboarding) | ID: province[0m ---
+  [92m[✅] Extraction Accuracy: PASSED[0m
+  [92m[ score: 1.00 ] Question Consistency[0m
+  [91m[ score: 0.50 ] Response Appropriateness[0m
+       [93mReason: The score is 0.50 because the response provided a type of residence instead of specifying a province, which is crucial to fully address the input question. However, the response still partially relates to the topic of residence, maintaining some relevance.[0m
+
+--- [1mTurn: onboarding_user_123_250616-0635 (onboarding) | ID: area_type[0m ---
+  [92m[✅] Extraction Accuracy: PASSED[0m
+  [91m[ score: 0.00 ] Question Consistency[0m
+       [93mReason: The score is 0.00 because the output did not address the question about the type of area someone lives in. Instead, it included irrelevant information about location and the purpose of collecting information, which did not pertain to the input question.[0m
+  [91m[ score: 0.00 ] Response Appropriateness[0m
+       [93mReason: The score is 0.00 because the response did not address the question about the province of residence, instead mentioning living on a farm without specifying the location. This lack of relevant information resulted in a score of zero.[0m
+
+--- [1mTurn: onboarding_user_123_250616-0635 (onboarding) | ID: relationship_status[0m ---
+  [92m[✅] Extraction Accuracy: PASSED[0m
+  [92m[ score: 1.00 ] Question Consistency[0m
+  [92m[ score: 1.00 ] Response Appropriateness[0m
+
+--- [1mTurn: onboarding_user_123_250616-0635 (onboarding) | ID: education_level[0m ---
+  [91m[❌] Extraction Accuracy: FAILED[0m
+       [91mDetails: Expected: 'Some high school', Got: 'Finished high school'[0m
+  [92m[ score: 1.00 ] Question Consistency[0m
+  [92m[ score: 1.00 ] Response Appropriateness[0m
+
+--- [1mTurn: onboarding_user_123_250616-0635 (onboarding) | ID: hunger_days[0m ---
+  [92m[✅] Extraction Accuracy: PASSED[0m
+  [92m[ score: 1.00 ] Question Consistency[0m
+  [92m[ score: 1.00 ] Response Appropriateness[0m
+
+--- [1mTurn: onboarding_user_123_250616-0635 (onboarding) | ID: num_children[0m ---
+  [91m[❌] Extraction Accuracy: FAILED[0m
+       [91mDetails: Expected: '1', Got: '1'[0m
+  [92m[ score: 1.00 ] Question Consistency[0m
+  [92m[ score: 1.00 ] Response Appropriateness[0m
+
+--- [1mTurn: onboarding_user_123_250616-0635 (onboarding) | ID: phone_ownership[0m ---
+  [92m[✅] Extraction Accuracy: PASSED[0m
+  [91m[ score: 0.67 ] Question Consistency[0m
+       [93mReason: The score is 0.67 because the response partially addresses the question about phone ownership, but includes an irrelevant statement about completing the onboarding process, which detracts from the overall relevancy.[0m
+  [92m[ score: 1.00 ] Response Appropriateness[0m
+
+--- [1mTurn: dma-assessment_user_123_250616-0635 (dma-assessment) | ID: 1[0m ---
+  [91m[❌] Extraction Accuracy: FAILED[0m
+       [91mDetails: Expected: 'I strongly agree', Got: 'nonsense'[0m
+  [91m[ score: 0.25 ] Question Consistency[0m
+       [93mReason: The score is 0.25 because the output included several irrelevant statements about confidence levels and living conditions, which did not address the input's request for agreement or disagreement with a health decision-making statement. However, the score is not lower because the output did attempt to engage with the topic of decision-making, albeit indirectly.[0m
+  [92m[ score: 1.00 ] Response Appropriateness[0m
+
+--- [1mTurn: dma-assessment_user_123_250616-0635 (dma-assessment) | ID: 2[0m ---
+  [91m[❌] Extraction Accuracy: FAILED[0m
+       [91mDetails: Expected: 'I strongly agree', Got: 'nonsense'[0m
+  [91m[ score: 0.14 ] Question Consistency[0m
+       [93mReason: The score is 0.14 because the output primarily focused on explaining response options rather than directly addressing the input statement about discussing health issues with a health worker. While the response options are relevant in a broader context, they do not directly answer the input question, leading to a lower relevancy score.[0m
+  [91m[ score: 0.00 ] Response Appropriateness[0m
+       [93mReason: The score is 0.00 because the statement 'I strongly agree.' does not directly address the question about confidence levels in discussing medical problems with a healthcare provider. The response lacks any reference to the provided scale or the context of the question, making it entirely irrelevant.[0m
+
+--- [1mTurn: dma-assessment_user_123_250616-0635 (dma-assessment) | ID: 3[0m ---
+  [91m[❌] Extraction Accuracy: FAILED[0m
+       [91mDetails: Expected: 'I strongly agree', Got: 'nonsense'[0m
+  [91m[ score: 0.14 ] Question Consistency[0m
+       [93mReason: The score is 0.14 because the output primarily consists of response options that do not directly address the input question about agreement with a health worker. While the options are related to expressing confidence levels, they do not provide a direct answer to the input statement, resulting in a low relevancy score.[0m
+  [92m[ score: 1.00 ] Response Appropriateness[0m
+
+--- [1mTurn: dma-assessment_user_123_250616-0635 (dma-assessment) | ID: 4[0m ---
+  [91m[❌] Extraction Accuracy: FAILED[0m
+       [91mDetails: Expected: 'I strongly agree', Got: 'nonsense'[0m
+  [91m[ score: 0.25 ] Question Consistency[0m
+       [93mReason: The score is 0.25 because the response included multiple irrelevant statements, such as discussing living on a farm and confidence levels, which did not directly address the input's request for agreement or disagreement on health improvement. However, the score is not lower because there was some attempt to engage with the topic of health.[0m
+  [92m[ score: 1.00 ] Response Appropriateness[0m
+
+--- [1mTurn: dma-assessment_user_123_250616-0635 (dma-assessment) | ID: 5[0m ---
+  [91m[❌] Extraction Accuracy: FAILED[0m
+       [91mDetails: Expected: 'I strongly agree', Got: 'nonsense'[0m
+  [91m[ score: 0.12 ] Question Consistency[0m
+       [93mReason: The score is 0.12 because the response included several irrelevant statements that did not directly address the input's request for a specific agreement level. The inclusion of unrelated details about location, phone access, and various confidence levels detracted from the focus on the input's options, resulting in a lower score.[0m
+  [92m[ score: 1.00 ] Response Appropriateness[0m
+
+
+==================================================
+              PERFORMANCE SUMMARY REPORT
+==================================================
+
+📊 [1mOnboarding Performance (7 turns evaluated):[0m
+  - Extraction Accuracy: 71.43%
+  - Question Consistency Score (Avg): 0.81
+  - Response Appropriateness Score (Avg): 0.79
+
+📊 [1mDma-assessment Performance (5 turns evaluated):[0m
+  - Extraction Accuracy: 0.00%
+  - Question Consistency Score (Avg): 0.18
+  - Response Appropriateness Score (Avg): 0.80
+
+==================================================

--- a/src/ai4gd_momconnect_haystack/evaluation/data/ground_truth.json
+++ b/src/ai4gd_momconnect_haystack/evaluation/data/ground_truth.json
@@ -1,87 +1,92 @@
 [
   {
-    "scenario_id": "onboarding_naledi_v1",
+    "scenario_id": "onboarding_user_123_250616-0635",
     "flow_type": "onboarding",
     "description": "Onboarding evaluation for Naledi, an anxious 19-year-old from a farm in North West.",
     "turns": [
       {
-        "question_name": "ask_province",
+        "question_name": "province",
         "llm_utterance": "Which province do you live in?",
         "user_utterance": "I live on a farm out in the North West.",
-        "ground_truth_delta": { "province": "North West" }
+        "user_response": "North West"
       },
       {
-        "question_name": "ask_area_type",
+        "question_name": "area_type",
         "llm_utterance": "What kind of area do you live in? 🏘️",
         "user_utterance": "I live on a farm.",
-        "ground_truth_delta": { "area_type": "Farm or smallholding" }
+        "user_response": "Farm or smallholding"
       },
       {
-        "question_name": "ask_relationship_status",
+        "question_name": "relationship_status",
         "llm_utterance": "What’s your current relationship status? 👤",
         "user_utterance": "I am single.",
-        "ground_truth_delta": { "relationship_status": "Single" }
+        "user_response": "Single"
       },
       {
-        "question_name": "ask_education_level",
+        "question_name": "education_level",
         "llm_utterance": "What’s your highest level of education? 📚",
         "user_utterance": "I only finished Grade 9 at school.",
-        "ground_truth_delta": { "education_level": "Some high school" }
+        "user_response": "Some high school"
       },
       {
-        "question_name": "ask_hunger_days",
+        "question_name": "hunger_days",
         "llm_utterance": "In the last week, how many days did you miss a meal because there wasn’t money for food? 🍞",
         "user_utterance": "I sometimes go without food, maybe 3-4 days.",
-        "ground_truth_delta": { "hunger_days": "3-4 days" }
+        "user_response": "3-4 days"
       },
       {
-        "question_name": "ask_num_children",
+        "question_name": "num_children",
         "llm_utterance": "How many children do you have? Count all your children of any age. 👶🏽",
         "user_utterance": "I have one little one already.",
-        "ground_truth_delta": { "num_children": 1 }
+        "user_response": 1
       },
       {
-        "question_name": "ask_phone_ownership",
+        "question_name": "phone_ownership",
         "llm_utterance": "Do you own the phone you’re using right now? 📱",
         "user_utterance": "No, I don't own this phone.",
-        "ground_truth_delta": { "phone_ownership": "No" }
+        "user_response": "No"
       }
     ]
   },
   {
-    "scenario_id": "assessment_naledi_v1",
-    "flow_type": "assessment",
+    "scenario_id": "dma-assessment_user_123_250616-0635",
+    "flow_type": "dma-assessment",
     "description": "Assessment evaluation for Naledi, handling conversational answers to scaled questions.",
     "turns": [
       {
-        "question_name": "ask_confidence_health_decisions",
+        "question_name": "confidence_health_decisions",
+        "question_number": 1,
         "llm_utterance": "Great! Your answers to these 5 quick questions can help us support you better.\n\nHow much do you agree or disagree with this statement?\n\n**I feel like I can make decisions about my health.**\n\nPlease reply with one of these options:\n• I strongly disagree\n• I disagree\n• I’m not sure\n• I agree\n• I strongly agree\n• Skip",
         "user_utterance": "I strongly agree",
-        "ground_truth_delta": { "processed_user_response": "I strongly agree" }
+        "user_response": "I strongly agree"
       },
       {
-        "question_name": "ask_confidence_discussing_problems",
+        "question_name": "confidence_discussing_problems",
+        "question_number": 2,
         "llm_utterance": "Thanks. How about this one?\n\n**I feel like I can talk about my health issues with a health worker.**\n\nPlease reply with one of these options:\n• I strongly disagree\n• I disagree\n• I’m not sure\n• I agree\n• I strongly agree\n• Skip",
         "user_utterance": "I strongly agree",
-        "ground_truth_delta": { "processed_user_response": "I strongly agree" }
+        "user_response": "I strongly agree" 
       },
       {
-        "question_name": "ask_confidence_questioning_provider",
+        "question_name": "confidence_questioning_provider",
+        "question_number": 3,
         "llm_utterance": "Here’s the next one 👇🏽\n\nHow much do you agree or disagree with this statement:\n\n**I feel that I can disagree with a health worker about my treatment plan.**\n\nPlease reply with one of these options:\n• I strongly disagree\n• I disagree\n• I’m not sure\n• I agree\n• I strongly agree\n• Skip",
         "user_utterance": "I don't know about that one.",
-        "ground_truth_delta": { "processed_user_response": "I strongly agree" }
+        "user_response": "I strongly agree"
       },
       {
-        "question_name": "ask_confidence_improving_health",
+        "question_name": "confidence_improving_health",
+        "question_number": 4,
         "llm_utterance": "Almost done! How much do you agree or disagree with this one:\n\n**I feel that I can do things to improve my health.**\n\nPlease reply with one of these options:\n• I strongly disagree\n• I disagree\n• I’m not sure\n• I agree\n• I strongly agree\n• Skip",
         "user_utterance": "I strongly agree",
-        "ground_truth_delta": { "processed_user_response": "I strongly agree" }
+        "user_response": "I strongly agree"
       },
       {
-        "question_name": "ask_confidence_finding_info",
+        "question_name": "confidence_finding_info",
+        "question_number": 5,
         "llm_utterance": "Great, thanks ⭐\n\nHere's the last one:\n\n**I feel that I can find information about my health from other places, not just a health worker.**\n\nPlease reply with one of these options:\n• I strongly disagree\n• I disagree\n• I’m not sure\n• I agree\n• I strongly agree\n• Skip",
         "user_utterance": "I strongly agree",
-        "ground_truth_delta": { "processed_user_response": "I strongly agree" }
+        "user_response": "I strongly agree"
       }
     ]
   }

--- a/src/ai4gd_momconnect_haystack/evaluation/data/llm_run_results.json
+++ b/src/ai4gd_momconnect_haystack/evaluation/data/llm_run_results.json
@@ -1,43 +1,111 @@
 [
   {
-    "scenario_id": "onboarding_naledi_v1",
+    "scenario_id": "onboarding_user_123_250616-0635",
     "flow_type": "onboarding",
     "turns": [
       {
-        "question_name": "ask_province",
-        "llm_utterance": "Which province do you currently reside in? 🏞️",
-        "actual_output": { "province": "North West" }
+        "question_name": "phone_ownership",
+        "question_number": null,
+        "llm_utterance": "Do you currently own the phone you're using to complete the onboarding process? \ud83d\udcf1",
+        "user_utterance": "No, I don't own this phone.",
+        "user_response": "No"
       },
       {
-        "question_name": "ask_education_level",
-        "llm_utterance": "What level of education have you completed? 📚",
-        "actual_output": { "education_level": "Some high school" }
+        "question_name": "relationship_status",
+        "question_number": null,
+        "llm_utterance": "What's your current relationship status? Are you single, in a relationship, married, or would you like to skip this question?",
+        "user_utterance": "I am single.",
+        "user_response": "Single"
       },
       {
-        "question_name": "ask_num_children",
-        "llm_utterance": "How many children do you have, if any? 👶🏽",
-        "actual_output": { "num_children": "one" }
+        "question_name": "province",
+        "question_number": null,
+        "llm_utterance": "Which province do you currently live in? We just need this information to complete your profile. \ud83c\udfde\ufe0f",
+        "user_utterance": "I live on a farm out in the North West",
+        "user_response": "North West"
+      },
+      {
+        "question_name": "area_type",
+        "question_number": null,
+        "llm_utterance": "Which province do you currently live in? We just need this information to complete your profile. \ud83c\udfde\ufe0f",
+        "user_utterance": "I live on a farm out in the North West",
+        "user_response": "Farm or smallholding"
+      },
+      {
+        "question_name": "hunger_days",
+        "question_number": null,
+        "llm_utterance": "Have you had to skip meals in the last week due to lack of money for food? \ud83c\udf5e",
+        "user_utterance": "I sometimes go without food, maybe 3-4 days.",
+        "user_response": "3-4 days"
+      },
+      {
+        "question_name": "num_children",
+        "question_number": null,
+        "llm_utterance": "How many children do you have, if any? We want to ensure we have all the details for your profile. \ud83d\udc76\ud83c\udffd",
+        "user_utterance": "I have one little one already.",
+        "user_response": "1"
+      },
+      {
+        "question_name": "education_level",
+        "question_number": null,
+        "llm_utterance": "What is the highest level of education you have completed so far? \ud83d\udcda We want to make sure your profile is complete.",
+        "user_utterance": "I only finished Grade 9 at school.",
+        "user_response": "Finished high school"
       }
     ]
   },
   {
-    "scenario_id": "assessment_naledi_v1",
-    "flow_type": "assessment",
+    "scenario_id": "dma-assessment_user_123_250616-0635",
+    "flow_type": "dma-assessment",
+    "overall_score": 0,
+    "score_percentage": 0.0,
+    "assessment_min_score": 0,
+    "assessment_max_score": 20,
     "turns": [
       {
-        "question_name": "ask_confidence_health_decisions",
-        "llm_utterance": "How confident are you making decisions about your health?",
-        "actual_output": { "processed_user_response": "Confident" }
+        "question_name": null,
+        "question_number": 1,
+        "llm_utterance": "How confident are you in making decisions about your health, especially considering your current living situation on a farm or smallholding in the North West province?\n    \n    Valid Responses:\n    1 - Not at all confident\n    2 - A little confident\n    3 - Somewhat confident\n    4 - Confident\n    5 - Very confident",
+        "user_utterance": "I strongly agree",
+        "user_response": "nonsense",
+        "score": 0,
+        "score_error": "User's answer is not a valid, scorable option."
       },
       {
-        "question_name": "ask_confidence_discussing_problems",
-        "llm_utterance": "How confident are you discussing medical problems with a doctor?",
-        "actual_output": { "processed_user_response": "A little confident" }
+        "question_name": null,
+        "question_number": 2,
+        "llm_utterance": "How confident are you discussing your medical problems with your healthcare provider? \nValid Responses:\n1 - Not at all confident\n2 - A little confident\n3 - Somewhat confident\n4 - Confident\n5 - Very confident",
+        "user_utterance": "I strongly agree",
+        "user_response": "nonsense",
+        "score": 0,
+        "score_error": "User's answer is not a valid, scorable option."
       },
       {
-        "question_name": "ask_confidence_questioning_provider",
-        "llm_utterance": "I feel confident questioning my provider about my treatment.",
-        "actual_output": { "processed_user_response": "skipped" }
+        "question_name": null,
+        "question_number": 3,
+        "llm_utterance": "Do you feel confident questioning your healthcare provider about your treatment?\n    Valid Responses:\n    1 - Not at all confident\n    2 - A little confident\n    3 - Somewhat confident\n    4 - Confident\n    5 - Very confident",
+        "user_utterance": "I strongly agree",
+        "user_response": "nonsense",
+        "score": 0,
+        "score_error": "User's answer is not a valid, scorable option."
+      },
+      {
+        "question_name": null,
+        "question_number": 4,
+        "llm_utterance": "How confident are you in taking actions to improve your health, considering your current living situation on a farm or smallholding in the North West province?\n    Valid Responses:\n    1 - Not at all confident\n    2 - A little confident\n    3 - Somewhat confident\n    4 - Confident\n    5 - Very confident",
+        "user_utterance": "I strongly agree",
+        "user_response": "nonsense",
+        "score": 0,
+        "score_error": "User's answer is not a valid, scorable option."
+      },
+      {
+        "question_name": null,
+        "question_number": 5,
+        "llm_utterance": "How confident are you in finding information about your health problems from other sources, considering your location in North West and limited access to a phone?\n    Valid Responses:\n    1 - Not at all confident\n    2 - A little confident\n    3 - Somewhat confident\n    4 - Confident\n    5 - Very confident",
+        "user_utterance": "I strongly agree",
+        "user_response": "nonsense",
+        "score": 0,
+        "score_error": "User's answer is not a valid, scorable option."
       }
     ]
   }

--- a/src/ai4gd_momconnect_haystack/evaluation/evaluator.py
+++ b/src/ai4gd_momconnect_haystack/evaluation/evaluator.py
@@ -23,11 +23,12 @@ logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
 # UPDATED: Added a simple class for terminal colors to improve report readability.
 class Colors:
     """Simple ANSI color codes for terminal output."""
-    OK = '\033[92m'      # GREEN
-    WARNING = '\033[93m' # YELLOW
-    FAIL = '\033[91m'    # RED
-    BOLD = '\033[1m'     # BOLD
-    ENDC = '\033[0m'     # RESET
+
+    OK = "\033[92m"  # GREEN
+    WARNING = "\033[93m"  # YELLOW
+    FAIL = "\033[91m"  # RED
+    BOLD = "\033[1m"  # BOLD
+    ENDC = "\033[0m"  # RESET
 
 
 def load_json_file(file_path: Path) -> list[dict] | None:
@@ -80,13 +81,21 @@ def run_evaluation_suite(
     gt_lookup = {}
     for s in gt_scenarios:
         for t in s.get("turns", []):
-            identifier = t.get("question_name") if "onboarding" in s["flow_type"] else t.get("question_number")
+            identifier = (
+                t.get("question_name")
+                if "onboarding" in s["flow_type"]
+                else t.get("question_number")
+            )
             gt_lookup[(s["scenario_id"], s["flow_type"], identifier)] = t
 
     llm_results_lookup = {}
     for s in llm_results:
         for t in s.get("turns", []):
-            identifier = t.get("question_name") if "onboarding" in s["flow_type"] else t.get("question_number")
+            identifier = (
+                t.get("question_name")
+                if "onboarding" in s["flow_type"]
+                else t.get("question_number")
+            )
             llm_results_lookup[(s["scenario_id"], s["flow_type"], identifier)] = t
 
     collated_results: dict[tuple, dict] = {}
@@ -128,7 +137,7 @@ def run_evaluation_suite(
             actual_extraction_str = llm_result_turn.get("user_response", "")
             exact_match_passed = actual_extraction_str == expected_extraction_str
 
-            q_score, q_reason  = _get_metric_details(q_consistency_result)
+            q_score, q_reason = _get_metric_details(q_consistency_result)
             r_score, r_reason = _get_metric_details(r_appropriateness_result)
 
             collated_results[key] = {
@@ -153,34 +162,38 @@ def present_results(all_results: dict[tuple, dict]):
     print("              DETAILED TURN-BY-TURN REPORT")
     print("=" * 50)
     for (scenario_id, flow_type, turn_identifier), res in all_results.items():
-        print(f"\n--- {Colors.BOLD}Turn: {scenario_id} ({flow_type}) | ID: {turn_identifier}{Colors.ENDC} ---")
+        print(
+            f"\n--- {Colors.BOLD}Turn: {scenario_id} ({flow_type}) | ID: {turn_identifier}{Colors.ENDC} ---"
+        )
 
         # Extraction Accuracy Result
         if res.get("exact_match_passed"):
             print(f"  {Colors.OK}[✅] Extraction Accuracy: PASSED{Colors.ENDC}")
         else:
             print(f"  {Colors.FAIL}[❌] Extraction Accuracy: FAILED{Colors.ENDC}")
-            print(f"       {Colors.FAIL}Details: {res.get('extraction_details', 'No details available.')}{Colors.ENDC}")
+            print(
+                f"       {Colors.FAIL}Details: {res.get('extraction_details', 'No details available.')}{Colors.ENDC}"
+            )
 
         # Question Consistency Result
-        qc_score = res.get('question_consistency_score', 0.0)
-        qc_reason = res.get('question_consistency_reason')
+        qc_score = res.get("question_consistency_score", 0.0)
+        qc_reason = res.get("question_consistency_reason")
         qc_color = Colors.OK if qc_score >= 0.7 else Colors.FAIL
         print(
             f"  {qc_color}[ score: {qc_score:.2f} ] Question Consistency{Colors.ENDC}"
         )
         if qc_reason and qc_score < 0.7:
-             print(f"       {Colors.WARNING}Reason: {qc_reason}{Colors.ENDC}")
+            print(f"       {Colors.WARNING}Reason: {qc_reason}{Colors.ENDC}")
 
         # Response Appropriateness Result
-        ra_score = res.get('response_appropriateness_score', 0.0)
-        ra_reason = res.get('response_appropriateness_reason')
+        ra_score = res.get("response_appropriateness_score", 0.0)
+        ra_reason = res.get("response_appropriateness_reason")
         ra_color = Colors.OK if ra_score >= 0.7 else Colors.FAIL
         print(
             f"  {ra_color}[ score: {ra_score:.2f} ] Response Appropriateness{Colors.ENDC}"
         )
         if ra_reason and ra_score < 0.7:
-             print(f"       {Colors.WARNING}Reason: {ra_reason}{Colors.ENDC}")
+            print(f"       {Colors.WARNING}Reason: {ra_reason}{Colors.ENDC}")
 
     summary_data: dict[str, list] = {}
     for (scenario_id, flow_type, question_name), res in all_results.items():
@@ -199,7 +212,9 @@ def present_results(all_results: dict[tuple, dict]):
         qc_avg = sum(r["question_consistency_score"] for r in results_list) / total
         ra_avg = sum(r["response_appropriateness_score"] for r in results_list) / total
 
-        print(f"\n📊 {Colors.BOLD}{flow_type.capitalize()} Performance ({total} turns evaluated):{Colors.ENDC}")
+        print(
+            f"\n📊 {Colors.BOLD}{flow_type.capitalize()} Performance ({total} turns evaluated):{Colors.ENDC}"
+        )
         print(f"  - Extraction Accuracy: {ea_rate:.2%}")
         print(f"  - Question Consistency Score (Avg): {qc_avg:.2f}")
         print(f"  - Response Appropriateness Score (Avg): {ra_avg:.2f}")

--- a/src/ai4gd_momconnect_haystack/main.py
+++ b/src/ai4gd_momconnect_haystack/main.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from datetime import datetime
 
 from . import tasks
 
@@ -35,6 +36,7 @@ def run_simulation():
     max_onboarding_steps = 10  # Safety break
     chat_history = []
     onboarding_turns = []
+    flow_type = "onboarding"
 
     # Simulate Onboarding
     for attempt in range(max_onboarding_steps):
@@ -61,7 +63,10 @@ def run_simulation():
         )
 
         # Identify what changed in user_context
-        diff_keys = [k for k in user_context if user_context[k] != previous_context.get(k)]
+        diff_keys = [
+            k for k in user_context
+            if user_context[k] != previous_context.get(k)
+        ]
         if len(diff_keys) == 1:
             updated_field = diff_keys[0]
             onboarding_turns.append({
@@ -74,8 +79,10 @@ def run_simulation():
             logger.warning(f"Unexpected diff in context at step {attempt + 1}: {diff_keys}")
 
     simulation_results.append({
-        "scenario_id": "onboarding_naledi_v1",  # TODO: Define scenario ID
-        "flow_type": "onboarding",
+        "scenario_id": generate_scenario_id(
+            flow_type=flow_type, username="user_123"
+        ),   # TODO: Find a way to pass the username dynamically
+        "flow_type": flow_type,
         "turns": onboarding_turns
     })
 
@@ -86,6 +93,7 @@ def run_simulation():
     user_context["goal"] = "Complete the assessment"
     max_assessment_steps = 10  # Safety break
     assessment_turns = []
+    flow_type = "dma_assessment"
 
     # Simulate Assessment
     while current_assessment_step < max_assessment_steps:
@@ -128,13 +136,26 @@ def run_simulation():
         })
 
     simulation_results.append({
-        "scenario_id": "assessment_naledi_v1",  # TODO: Define scenario ID
-        "flow_type": "dma_assessment",
+        "scenario_id": generate_scenario_id(
+            flow_type=flow_type, username="user_123"
+        ),   # TODO: Find a way to pass the username dynamically
+        "flow_type": flow_type,
         "turns": assessment_turns
     })
 
     logger.info("--- Simulation Complete ---")
     return simulation_results
+
+
+def generate_scenario_id(
+    flow_type: str, username: str
+) -> str:
+    """
+    Generates a unique scenario ID based on flow type, name, version,
+    and current timestamp.
+    """
+    timestamp = datetime.now().strftime("%y%m%d-%H%M")
+    return f"{flow_type}_{username}_{timestamp}"
 
 
 def main():

--- a/src/ai4gd_momconnect_haystack/main.py
+++ b/src/ai4gd_momconnect_haystack/main.py
@@ -65,27 +65,32 @@ def run_simulation():
 
         # Identify what changed in user_context
         diff_keys = [
-            k for k in user_context
-            if user_context[k] != previous_context.get(k)
+            k for k in user_context if user_context[k] != previous_context.get(k)
         ]
         if len(diff_keys) == 1:
             updated_field = diff_keys[0]
-            onboarding_turns.append({
-                "question_name": updated_field,
-                "llm_utterance": contextualized_question,
-                "user_utterance": user_response,
-                "llm_extracted_user_response": user_context[updated_field]
-            })
+            onboarding_turns.append(
+                {
+                    "question_name": updated_field,
+                    "llm_utterance": contextualized_question,
+                    "user_utterance": user_response,
+                    "llm_extracted_user_response": user_context[updated_field],
+                }
+            )
         else:
-            logger.warning(f"Unexpected diff in context at step {attempt + 1}: {diff_keys}")
+            logger.warning(
+                f"Unexpected diff in context at step {attempt + 1}: {diff_keys}"
+            )
 
-    simulation_results.append({
-        "scenario_id": generate_scenario_id(
-            flow_type=flow_type, username="user_123"
-        ),   # TODO: Find a way to pass the username dynamically
-        "flow_type": flow_type,
-        "turns": onboarding_turns
-    })
+    simulation_results.append(
+        {
+            "scenario_id": generate_scenario_id(
+                flow_type=flow_type, username="user_123"
+            ),  # TODO: Find a way to pass the username dynamically
+            "flow_type": flow_type,
+            "turns": onboarding_turns,
+        }
+    )
 
     # ** Assessment Scenario **
     print("")
@@ -129,28 +134,30 @@ def run_simulation():
         # processed_user_response = result['processed_user_response']
         current_assessment_step = result["current_assessment_step"]
         processed_user_response = result["processed_user_response"]
-        assessment_turns.append({
-            "question_name": current_assessment_step,
-            "llm_utterance": contextualized_question,
-            "user_utterance": user_response,
-            "llm_extracted_user_response": processed_user_response
-        })
+        assessment_turns.append(
+            {
+                "question_name": current_assessment_step,
+                "llm_utterance": contextualized_question,
+                "user_utterance": user_response,
+                "llm_extracted_user_response": processed_user_response,
+            }
+        )
 
-    simulation_results.append({
-        "scenario_id": generate_scenario_id(
-            flow_type=flow_type, username="user_123"
-        ),   # TODO: Find a way to pass the username dynamically
-        "flow_type": flow_type,
-        "turns": assessment_turns
-    })
+    simulation_results.append(
+        {
+            "scenario_id": generate_scenario_id(
+                flow_type=flow_type, username="user_123"
+            ),  # TODO: Find a way to pass the username dynamically
+            "flow_type": flow_type,
+            "turns": assessment_turns,
+        }
+    )
 
     logger.info("--- Simulation Complete ---")
     return simulation_results
 
 
-def generate_scenario_id(
-    flow_type: str, username: str
-) -> str:
+def generate_scenario_id(flow_type: str, username: str) -> str:
     """
     Generates a unique scenario ID based on flow type, name, version,
     and current timestamp.
@@ -162,7 +169,7 @@ def generate_scenario_id(
 def _score_single_run(
     run_result: dict[str, Any],
     scorable_assessments_map: dict[str, list],
-    full_simulation_output: list[dict[str, Any]]
+    full_simulation_output: list[dict[str, Any]],
 ) -> None:
     """
     Scores a single run from the simulation if it's a scorable assessment.
@@ -199,9 +206,11 @@ def _score_single_run(
 
     except Exception as e:
         # Robustly catch any unexpected errors during the scoring process
-        logging.error(f"An unexpected error occurred while scoring '{flow_type}': {e}", exc_info=True)
-        run_result['scoring_error'] = str(e)
-
+        logging.error(
+            f"An unexpected error occurred while scoring '{flow_type}': {e}",
+            exc_info=True,
+        )
+        run_result["scoring_error"] = str(e)
 
 
 def main():

--- a/src/ai4gd_momconnect_haystack/main.py
+++ b/src/ai4gd_momconnect_haystack/main.py
@@ -263,7 +263,9 @@ def main() -> None:
     doc_store_kab = load_json_and_validate(DOC_STORE_KAB_PATH, dict)
 
     if doc_store_dma is None or doc_store_kab is None:
-        logging.critical("Could not load one or more required doc store files. Exiting.")
+        logging.critical(
+            "Could not load one or more required doc store files. Exiting."
+        )
         return
 
     all_doc_stores = {**doc_store_dma, **doc_store_kab}

--- a/src/ai4gd_momconnect_haystack/main.py
+++ b/src/ai4gd_momconnect_haystack/main.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 from . import tasks
@@ -13,6 +14,7 @@ def run_simulation():
     Runs a simulation of the onboarding and assessment process using the pipelines.
     """
     logger.info("--- Starting Haystack POC Simulation ---")
+    simulation_results = []
 
     # --- Simulation ---
     # ** Onboarding Scenario **
@@ -32,6 +34,7 @@ def run_simulation():
     }
     max_onboarding_steps = 10  # Safety break
     chat_history = []
+    onboarding_turns = []
 
     # Simulate Onboarding
     for attempt in range(max_onboarding_steps):
@@ -52,9 +55,29 @@ def run_simulation():
         chat_history.append("User to System: " + user_response + "\n> ")
 
         ### Endpoint 2: Turn can call to get extracted data from a user response.
+        previous_context = user_context.copy()
         user_context = tasks.extract_onboarding_data_from_response(
             user_response, user_context, chat_history
         )
+
+        # Identify what changed in user_context
+        diff_keys = [k for k in user_context if user_context[k] != previous_context.get(k)]
+        if len(diff_keys) == 1:
+            updated_field = diff_keys[0]
+            onboarding_turns.append({
+                "question_name": updated_field,
+                "llm_utterance": contextualized_question,
+                "user_utterance": user_response,
+                "llm_extracted_user_response": user_context[updated_field]
+            })
+        else:
+            logger.warning(f"Unexpected diff in context at step {attempt + 1}: {diff_keys}")
+
+    simulation_results.append({
+        "scenario_id": "onboarding_naledi_v1",  # TODO: Define scenario ID
+        "flow_type": "onboarding",
+        "turns": onboarding_turns
+    })
 
     # ** Assessment Scenario **
     print("")
@@ -62,6 +85,7 @@ def run_simulation():
     current_assessment_step = 0
     user_context["goal"] = "Complete the assessment"
     max_assessment_steps = 10  # Safety break
+    assessment_turns = []
 
     # Simulate Assessment
     while current_assessment_step < max_assessment_steps:
@@ -95,8 +119,22 @@ def run_simulation():
             continue
         # processed_user_response = result['processed_user_response']
         current_assessment_step = result["current_assessment_step"]
+        processed_user_response = result["processed_user_response"]
+        assessment_turns.append({
+            "question_name": current_assessment_step,
+            "llm_utterance": contextualized_question,
+            "user_utterance": user_response,
+            "llm_extracted_user_response": processed_user_response
+        })
+
+    simulation_results.append({
+        "scenario_id": "assessment_naledi_v1",  # TODO: Define scenario ID
+        "flow_type": "dma_assessment",
+        "turns": assessment_turns
+    })
 
     logger.info("--- Simulation Complete ---")
+    return simulation_results
 
 
 def main():
@@ -104,4 +142,9 @@ def main():
         level=logging.INFO,
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
-    run_simulation()
+    run_output = run_simulation()
+
+    # Pretty-print to screen
+    pretty_output = json.dumps(run_output, indent=2)
+    print("\n--- Simulation Output ---")
+    print(pretty_output)

--- a/src/ai4gd_momconnect_haystack/main.py
+++ b/src/ai4gd_momconnect_haystack/main.py
@@ -262,10 +262,8 @@ def main() -> None:
     doc_store_dma = load_json_and_validate(DOC_STORE_DMA_PATH, dict)
     doc_store_kab = load_json_and_validate(DOC_STORE_KAB_PATH, dict)
 
-    if not all([doc_store_dma, doc_store_kab]):
-        logging.critical(
-            "Could not load one or more required doc store files. Exiting."
-        )
+    if doc_store_dma is None or doc_store_kab is None:
+        logging.critical("Could not load one or more required doc store files. Exiting.")
         return
 
     all_doc_stores = {**doc_store_dma, **doc_store_kab}

--- a/src/ai4gd_momconnect_haystack/models.py
+++ b/src/ai4gd_momconnect_haystack/models.py
@@ -1,0 +1,53 @@
+# models.py
+
+from typing import Any
+from pydantic import BaseModel, Field, model_validator
+
+
+class Question(BaseModel):
+    """
+    Defines a flexible structure for any question from the doc store.
+    It can handle scorable (assessment) and non-scorable (onboarding) questions.
+    """
+
+    question_number: int
+    question_name: str | None = None
+    content: str | None = None
+    pre_content: str | None = Field(None, alias="pre-content")
+    post_content: str | None = Field(None, alias="post-content")
+    valid_responses: dict[str, int] | list[str]
+    content_type: str | None = None
+    collects: str | None = None
+    reason: str | None = None
+
+
+class Turn(BaseModel):
+    """
+    Defines a single turn in a conversation.
+    The validator ensures it has at least one valid identifier.
+    """
+
+    question_name: str | None = None
+    question_number: int | None = None
+    llm_utterance: str | None = None
+    user_utterance: str | None = None
+    user_response: str = Field(alias="llm_extracted_user_response")
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_at_least_one_identifier_exists(cls, data: Any) -> Any:
+        """Ensures each turn has 'question_name' or 'question_number'."""
+        if isinstance(data, dict):
+            if "question_name" not in data and "question_number" not in data:
+                raise ValueError(
+                    "Turn must have either 'question_name' or 'question_number'"
+                )
+        return data
+
+
+class AssessmentRun(BaseModel):
+    """Defines a full assessment run from the simulation output."""
+
+    scenario_id: str
+    flow_type: str
+    turns: list[Turn]

--- a/src/ai4gd_momconnect_haystack/static_content/dma.json
+++ b/src/ai4gd_momconnect_haystack/static_content/dma.json
@@ -2,68 +2,73 @@
     "dma-assessment": [
         {
             "question_number": 1,
+            "question_name": "confident_in_making_health_decisions",
             "content": "How much do you agree or disagree with this statement:\n\n*I feel like I can make decisions about my health.*",
             "content_type": "assessment_question",
-            "valid_responses": [
-                "I strongly disagree",
-                "I disagree",
-                "I'm not sure",
-                "I agree",
-                "I strongly agree",
-                "Skip"
-            ]
+            "valid_responses": {
+                "I strongly disagree": 0,
+                "I disagree": 1,
+                "I'm not sure": 2,
+                "I agree": 3,
+                "I strongly agree": 4,
+                "Skip": 0
+            }
         },
         {
             "question_number": 2,
+            "question_name": "confident_in_talking_to_health_worker",
             "content": "How about this one?\n\n*I feel like I can talk about my health issues with a health worker.*",
             "content_type": "assessment_question",
-            "valid_responses": [
-                "I strongly disagree",
-                "I disagree",
-                "I'm not sure",
-                "I agree",
-                "I strongly agree",
-                "Skip"
-            ]
+            "valid_responses": {
+                "I strongly disagree": 0,
+                "I disagree": 1,
+                "I'm not sure": 2,
+                "I agree": 3,
+                "I strongly agree": 4,
+                "Skip": 0
+            }
         },
         {
             "question_number": 3,
+            "question_name": "confident_in_disagreeing_with_health_worker",
             "content": "Here’s the next one 👇🏽\n\n*I feel that I can disagree with a health worker about my treatment plan.*",
             "content_type": "assessment_question",
-            "valid_responses": [
-                "I strongly disagree",
-                "I disagree",
-                "I'm not sure",
-                "I agree",
-                "I strongly agree",
-                "Skip"
-            ]
+            "valid_responses": {
+                "I strongly disagree": 0,
+                "I disagree": 1,
+                "I'm not sure": 2,
+                "I agree": 3,
+                "I strongly agree": 4,
+                "Skip": 0
+            }
         },
         {
             "question_number": 4,
+            "question_name": "confident_in_ability_to_improve_health",
             "content": "Almost done!\n\n*I feel that I can do things to improve my health.*",
             "content_type": "assessment_question",
-            "valid_responses": [
-                "I strongly disagree",
-                "I disagree",
-                "I'm not sure",
-                "I agree",
-                "I strongly agree",
-                "Skip"
-            ]
+            "valid_responses": {
+                "I strongly disagree": 0,
+                "I disagree": 1,
+                "I'm not sure": 2,
+                "I agree": 3,
+                "I strongly agree": 4,
+                "Skip": 0
+            }
         },
         {
             "question_number": 5,
+            "question_name": "confident_in_finding_external_health_info",
             "content": "And the last one ⭐\n\n*I feel that I can find information about my health from other places, not just a health worker.*",
             "content_type": "assessment_question",
-            "valid_responses": [
-                "I strongly disagree",
-                "I disagree",
-                "I'm not sure",
-                "I agree",
-                "I strongly agree",
-                "Skip"
-            ]
+            "valid_responses": {
+                "I strongly disagree": 0,
+                "I disagree": 1,
+                "I'm not sure": 2,
+                "I agree": 3,
+                "I strongly agree": 4,
+                "Skip": 0
+            }
         }
     ]
 }

--- a/src/ai4gd_momconnect_haystack/static_content/kab.json
+++ b/src/ai4gd_momconnect_haystack/static_content/kab.json
@@ -2,166 +2,180 @@
     "behaviour-assessment": [
         {
             "question_number": 1,
+            "question_name": "antenatal_care_visit_count",
             "content": "*So far in this pregnancy, how many times have you gone to the clinic for a pregnancy check-up?* 🫃🏽",
             "content_type": "assessment_question",
-            "valid_responses": [
-                "0 - None",
-                "1",
-                "2",
-                "3",
-                "4",
-                "5",
-                "6",
-                "7",
-                "More than 7"
-            ]
+            "valid_responses": {
+                "0 - None": 0,
+                "1": 1,
+                "2": 2,
+                "3": 3,
+                "4": 3,
+                "5": 3,
+                "6": 3,
+                "7": 3,
+                "More than 7": 3,
+                "Skip": 0
+            }
         },
         {
             "question_number": 2,
+            "question_name": "made_diet_changes_based_on_health_worker",
             "content": "*In this pregnancy, have you made any changes to your diet based on information from the health worker?* 🫃🏽",
             "content_type": "assessment_question",
-            "valid_responses": [
-                "Yes",
-                "No",
-                "Skip"
-            ]
+            "valid_responses": {
+                "Yes": 1,
+                "No": 2,
+                "Skip": 0
+            }
         },
         {
             "question_number": 3,
+            "question_name": "tetanus_vaccine_doses_received",
             "content": "*So far in this pregnancy, how many doses of the tetanus vaccine (Tdap) have you received?* 🫃🏽",
             "content_type": "assessment_question",
-            "valid_responses": [
-                "0 - None",
-                "1",
-                "Skip"
-            ]
+            "valid_responses": {
+                "0": 0,
+                "1": 1,
+                "Skip": 0
+            }
         },
         {
             "question_number": 4,
+            "question_name": "consumed_alcohol_or_smoking_during_pregnancy",
             "pre-content": "*Since becoming pregnant, have you drunk any alcohol or smoked at all?* 🫃🏽",
             "post-content": "*Since joining MomConnect, have you drunk any alcohol or smoked at all?* 🫃🏽",
             "content_type": "assessment_question",
-            "valid_responses": [
-                "Yes",
-                "No",
-                "Skip"
-            ]
+            "valid_responses": {
+                "Yes": 0,
+                "No": 1,
+                "Skip": 0
+            }
         }
     ],
     "knowledge-assessment": [
         {
             "question_number": 1,
+            "question_name": "first_pregnancy_checkup_timing",
             "content": "*When do you think a pregnant woman should get her first pregnancy check-up?* 🤰🏽",
             "content_type": "assessment_question",
-            "valid_responses": [
-                "Before 14 weeks",
-                "At about 16 weeks",
-                "At about 20 weeks",
-                "At about 24 weeks",
-                "At birth",
-                "I don't know",
-                "Skip"
-            ]
+            "valid_responses": {
+                "Before 14 weeks": 0,
+                "At about 16 weeks": 1,
+                "At about 20 weeks": 0,
+                "At about 24 weeks": 0,
+                "At birth": 0,
+                "I don't know": 0,
+                "Skip": 0
+            }
         },
         {
             "question_number": 2,
+            "question_name": "emergency_symptom_recognition",
             "content": "*During a pregnancy, which of these means you need to go to the hospital immediately?* 🤰🏽\n\n• You have contractions that stop when you move\n• Your tummy stays tight, hard and is very painful\n• Your lower back aches all day",
             "content_type": "assessment_question",
-            "valid_responses": [
-                "Contractions stop",
-                "Tight painful tummy",
-                "Lower back ache",
-                "I don't know",
-                "Skip"
-            ]
+            "valid_responses": {
+                "Contractions stop": 0,
+                "Tight painful tummy": 1,
+                "Lower back ache": 0,
+                "I don't know": 0,
+                "Skip": 0
+            }
         },
         {
             "question_number": 3,
+            "question_name": "pregnancy_checkup_frequency",
             "content": "*How many pregnancy check-ups should you go to during your pregnancy?* 🤰🏽",
             "content_type": "assessment_question",
-            "valid_responses": [
-                "1 to 4 check-ups",
-                "5 to 7 check-ups",
-                "8 or more check-ups",
-                "0 - None",
-                "I don't know",
-                "Skip"
-            ]
+            "valid_responses": {
+                "1 to 4 check-ups": 0,
+                "5 to 7 check-ups": 1,
+                "8 or more check-ups": 1,
+                "0 - None": 0,
+                "I don't know": 0,
+                "Skip": 0
+            }
         },
         {
             "question_number": 4,
+            "question_name": "should_breastfeed_within_hour",
             "content": "*Should a baby be breastfed within the first hour of birth?* 🤰🏽",
             "content_type": "assessment_question",
-            "valid_responses": [
-                "Yes",
-                "No",
-                "I don't know",
-                "Skip"
-            ]
+            "valid_responses": {
+                "Yes": 1,
+                "No": 0,
+                "I don't know": 0,
+                "Skip": 0
+            }
         },
         {
             "question_number": 5,
+            "question_name": "vaccine_protection",
             "content": "*Who does this vaccine protect?* 🤰🏽",
             "content_type": "assessment_question",
-            "valid_responses": [
-                "You",
-                "Your baby only",
-                "You and baby",
-                "I don't know",
-                "Skip"
-            ]
+            "valid_responses": {
+                "You": 0,
+                "Your baby only": 0,
+                "You and baby": 1,
+                "I don't know": 0,
+                "Skip": 0
+            }
         },
         {
             "question_number": 6,
+            "question_name": "understands_iron_folic_acid_benefits",
             "content": "*Are iron and folic acid supplements good for you and your unborn baby?* 🤰🏽",
             "content_type": "assessment_question",
-            "valid_responses": [
-                "Yes",
-                "No",
-                "I don't know",
-                "Skip"
-            ]
+            "valid_responses": {
+                "Yes": 1,
+                "No": 0,
+                "I don't know": 0,
+                "Skip": 0
+            }
         }
     ],
     "attitude-assessment": [
         {
             "question_number": 1,
+            "question_name": "believes_in_checkup_importance",
             "content": "Do you agree with this statement?\n\n*Pregnancy check-ups are a good way to check that you and your unborn baby are healthy.* 🫄🏽",
             "content_type": "assessment_question",
-            "valid_responses": [
-                "I strongly agree",
-                "I agree",
-                "I'm not sure",
-                "I disagree",
-                "I strongly disagree",
-                "Skip"
-            ]
+            "valid_responses": {
+                "I strongly agree": 5,
+                "I agree": 4,
+                "I'm not sure": 3,
+                "I disagree": 2,
+                "I strongly disagree": 1,
+                "Skip": 0
+            }
         },
         {
             "question_number": 2,
+            "question_name": "believes_home_birth_is_safer",
             "content": "What about this one…\n\n*Home birth is safer than giving birth in a hospital.* 🫄🏽",
             "content_type": "assessment_question",
-            "valid_responses": [
-                "I strongly agree",
-                "I agree",
-                "I'm not sure",
-                "I disagree",
-                "I strongly disagree",
-                "Skip"
-            ]
+            "valid_responses": {
+                "I strongly agree": 1,
+                "I agree": 2,
+                "I'm not sure": 3,
+                "I disagree": 4,
+                "I strongly disagree": 5,
+                "Skip": 0
+            }
         },
         {
             "question_number": 3,
+            "question_name": "believes_in_hiv_testing",
             "content": "And…\n\n*It’s important for a pregnant woman to get an HIV test when she is pregnant.* 🫄🏽",
             "content_type": "assessment_question",
-            "valid_responses": [
-                "I strongly agree",
-                "I agree",
-                "I'm not sure",
-                "I disagree",
-                "I strongly disagree",
-                "Skip"
-            ]
+            "valid_responses": {
+                "I strongly agree": 5,
+                "I agree": 4,
+                "I'm not sure": 3,
+                "I disagree": 2,
+                "I strongly disagree": 1,
+                "Skip": 0
+            }
         }
     ]
 }

--- a/src/ai4gd_momconnect_haystack/tasks.py
+++ b/src/ai4gd_momconnect_haystack/tasks.py
@@ -158,3 +158,124 @@ def validate_assessment_answer(
         "processed_user_response": processed_user_response,
         "current_assessment_step": current_assessment_step,
     }
+
+
+def _calculate_assessment_score_range(
+    assessment_questions: list[dict[str, Any]]
+) -> tuple[int, int]:
+    """
+    Calculates the minimum and maximum possible scores for an assessment.
+    """
+    total_min_score = 0
+    total_max_score = 0
+
+    for question in assessment_questions:
+        if not isinstance(question, dict):
+            continue
+
+        score_options = question.get("valid_responses", {})
+        if not score_options:
+            continue
+
+        valid_scores = []
+        for score_val in score_options.values():
+            try:
+                valid_scores.append(int(score_val))
+            except (ValueError, TypeError):
+                continue
+
+        if valid_scores:
+            total_min_score += min(valid_scores)
+            total_max_score += max(valid_scores)
+
+    return total_min_score, total_max_score
+
+
+def _score_and_format_turn(
+    turn: dict[str, Any],
+    question_lookup: dict[int, dict[str, Any]],
+) -> None:
+    """
+    Helper function to process one 'turn' from a simulation run. It adds the
+    score and a score_error message directly to the turn dictionary in-place.
+    """
+    turn["score"] = None
+    turn["score_error"] = "An unknown error occurred during scoring."
+
+    q_num_raw = turn.get("question_name")
+    if q_num_raw is None:
+        turn["score_error"] = "Turn is missing its question identifier."
+        logger.warning(f"{turn['score_error']}: {turn}")
+        return
+
+    try:
+        q_num = int(q_num_raw)
+    except (ValueError, TypeError):
+        turn["score_error"] = f"Invalid question identifier: {q_num_raw}."
+        logger.warning(f"{turn['score_error']}: {turn}")
+        return
+
+    question_data = question_lookup.get(q_num)
+    if not question_data:
+        turn["score_error"] = "Question not found in master assessment file."
+        logger.warning(f"{turn['score_error']} (q_num: {q_num})")
+        return
+
+    user_answer = turn.get("llm_extracted_user_response", "N/A")
+    score_options = question_data.get("valid_responses", {})
+    score_val = score_options.get(user_answer)
+
+    if score_val is None:
+        turn["score_error"] = "User's answer is not a valid, scorable option."
+        logger.warning(f"{turn['score_error']} (q_num: {q_num}, answer: '{user_answer}')")
+        return
+
+    try:
+        turn["score"] = int(score_val)
+        turn["score_error"] = None
+    except (ValueError, TypeError):
+        turn["score_error"] = f"Invalid score value '{score_val}' in master file."
+        logger.warning(f"{turn['score_error']} (q_num: {q_num}, answer: '{user_answer}')")
+
+
+def score_assessment_from_simulation(
+    simulation_output: list[dict[str, Any]],
+    assessment_id: str,
+    assessment_questions: list[dict[str, Any]],
+) -> dict | None:
+    """
+    Calculates the final score from a raw simulation output for a specific assessment.
+    """
+    logger.info(f"Calculating final score for '{assessment_id}' from simulation output...")
+
+    assessment_run = next(
+        (run for run in simulation_output if run.get("flow_type") == assessment_id), None
+    )
+    if not assessment_run or not isinstance(assessment_turns := assessment_run.get("turns"), list):
+        logger.error(f"Could not find a valid run for '{assessment_id}' in the simulation output.")
+        return None
+
+    question_lookup = {q["question_number"]: q for q in assessment_questions if "question_number" in q}
+
+    for turn in assessment_turns:
+        if isinstance(turn, dict):
+            _score_and_format_turn(turn, question_lookup)
+
+    # --- New Score Calculation Logic ---
+    min_possible_score, max_possible_score = _calculate_assessment_score_range(assessment_questions)
+    valid_user_scores = [turn["score"] for turn in assessment_turns if isinstance(turn.get("score"), int)]
+    user_total_score = sum(valid_user_scores)
+
+    user_score_percentage = 0.0
+    if max_possible_score > 0:
+        user_score_percentage = (user_total_score / max_possible_score) * 100
+
+    logger.info(f"Final score for '{assessment_id}' calculated: {user_total_score}")
+
+    return {
+        "overall_score": user_total_score,
+        "score_percentage": round(user_score_percentage, 2),
+        "assessment_min_score": min_possible_score,
+        "assessment_max_score": max_possible_score,
+        "results": assessment_turns,
+    }

--- a/src/ai4gd_momconnect_haystack/tasks.py
+++ b/src/ai4gd_momconnect_haystack/tasks.py
@@ -161,7 +161,7 @@ def validate_assessment_answer(
 
 
 def _calculate_assessment_score_range(
-    assessment_questions: list[dict[str, Any]]
+    assessment_questions: list[dict[str, Any]],
 ) -> tuple[int, int]:
     """
     Calculates the minimum and maximum possible scores for an assessment.
@@ -227,7 +227,9 @@ def _score_and_format_turn(
 
     if score_val is None:
         turn["score_error"] = "User's answer is not a valid, scorable option."
-        logger.warning(f"{turn['score_error']} (q_num: {q_num}, answer: '{user_answer}')")
+        logger.warning(
+            f"{turn['score_error']} (q_num: {q_num}, answer: '{user_answer}')"
+        )
         return
 
     try:
@@ -235,7 +237,9 @@ def _score_and_format_turn(
         turn["score_error"] = None
     except (ValueError, TypeError):
         turn["score_error"] = f"Invalid score value '{score_val}' in master file."
-        logger.warning(f"{turn['score_error']} (q_num: {q_num}, answer: '{user_answer}')")
+        logger.warning(
+            f"{turn['score_error']} (q_num: {q_num}, answer: '{user_answer}')"
+        )
 
 
 def score_assessment_from_simulation(
@@ -246,24 +250,37 @@ def score_assessment_from_simulation(
     """
     Calculates the final score from a raw simulation output for a specific assessment.
     """
-    logger.info(f"Calculating final score for '{assessment_id}' from simulation output...")
+    logger.info(
+        f"Calculating final score for '{assessment_id}' from simulation output..."
+    )
 
     assessment_run = next(
-        (run for run in simulation_output if run.get("flow_type") == assessment_id), None
+        (run for run in simulation_output if run.get("flow_type") == assessment_id),
+        None,
     )
-    if not assessment_run or not isinstance(assessment_turns := assessment_run.get("turns"), list):
-        logger.error(f"Could not find a valid run for '{assessment_id}' in the simulation output.")
+    if not assessment_run or not isinstance(
+        assessment_turns := assessment_run.get("turns"), list
+    ):
+        logger.error(
+            f"Could not find a valid run for '{assessment_id}' in the simulation output."
+        )
         return None
 
-    question_lookup = {q["question_number"]: q for q in assessment_questions if "question_number" in q}
+    question_lookup = {
+        q["question_number"]: q for q in assessment_questions if "question_number" in q
+    }
 
     for turn in assessment_turns:
         if isinstance(turn, dict):
             _score_and_format_turn(turn, question_lookup)
 
     # --- New Score Calculation Logic ---
-    min_possible_score, max_possible_score = _calculate_assessment_score_range(assessment_questions)
-    valid_user_scores = [turn["score"] for turn in assessment_turns if isinstance(turn.get("score"), int)]
+    min_possible_score, max_possible_score = _calculate_assessment_score_range(
+        assessment_questions
+    )
+    valid_user_scores = [
+        turn["score"] for turn in assessment_turns if isinstance(turn.get("score"), int)
+    ]
     user_total_score = sum(valid_user_scores)
 
     user_score_percentage = 0.0

--- a/src/ai4gd_momconnect_haystack/utilities.py
+++ b/src/ai4gd_momconnect_haystack/utilities.py
@@ -1,6 +1,11 @@
 import json
+import argparse
 import logging
+from typing import Any
 from pathlib import Path
+from datetime import datetime
+from pydantic import BaseModel, ValidationError
+
 
 logger = logging.getLogger(__name__)
 
@@ -12,3 +17,84 @@ def read_json(filepath: Path) -> dict:
     except Exception as e:
         logger.error("Error loading JSON from %s: %s", filepath, e)
         raise
+
+
+def generate_scenario_id(flow_type: str, username: str) -> str:
+    """Generates a unique scenario ID."""
+    timestamp = datetime.now().strftime("%y%m%d-%H%M")
+    return f"{flow_type}_{username}_{timestamp}"
+
+
+def load_json_and_validate(
+    file_path: Path, model: type[BaseModel] | type[dict]
+) -> Any | None:
+    """
+    Loads a JSON file and validates its content against a Pydantic model or as a dict.
+    This is the primary gateway for safely loading any external JSON data.
+    """
+    try:
+        with file_path.open("r", encoding="utf-8") as f:
+            raw_data = json.load(f)
+
+        # Guard Clause: If the model is just 'dict', we are loading a raw
+        # doc_store. Return it directly without Pydantic validation.
+        # The validation for its contents is handled later in tasks.py.
+        if model is dict:
+            return raw_data
+
+        # If the model is a Pydantic model, proceed with validation.
+        if isinstance(raw_data, list):
+            return [model.model_validate(item) for item in raw_data]
+        return model.model_validate(raw_data)
+
+    except FileNotFoundError:
+        logging.error(f"File not found: {file_path}")
+    except ValidationError as e:
+        logging.error(f"Data validation error in {file_path}:\n{e}")
+    except Exception as e:
+        logging.error(f"An unexpected error occurred with {file_path}: {e}")
+    return None
+
+
+def save_json_file(data: list[dict[str, Any]], file_path: Path) -> None:
+    """Saves the final processed data to a JSON file."""
+    try:
+        # Ensure the output directory exists before writing.
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        with file_path.open("w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+        logging.info(f"Successfully saved final augmented output to {file_path}")
+    except Exception as e:
+        logging.error(f"An unexpected error occurred while writing to {file_path}: {e}")
+
+
+def parse_arguments() -> argparse.Namespace:
+    """Parses command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Score assessments from a simulation run."
+    )
+    parser.add_argument(
+        "--doc-store-dma",
+        type=Path,
+        required=True,
+        help="Path to the DMA JSON doc store file.",
+    )
+    parser.add_argument(
+        "--doc-store-kab",
+        type=Path,
+        required=True,
+        help="Path to the KAB JSON doc store file.",
+    )
+    parser.add_argument(
+        "--results",
+        type=Path,
+        required=True,
+        help="Path to the raw simulation output JSON file.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("final_augmented_output.json"),
+        help="Path for the final output file.",
+    )
+    return parser.parse_args()

--- a/src/ai4gd_momconnect_haystack/utilities.py
+++ b/src/ai4gd_momconnect_haystack/utilities.py
@@ -66,4 +66,3 @@ def save_json_file(data: list[dict[str, Any]], file_path: Path) -> None:
         logging.info(f"Successfully saved final augmented output to {file_path}")
     except Exception as e:
         logging.error(f"An unexpected error occurred while writing to {file_path}: {e}")
-

--- a/src/ai4gd_momconnect_haystack/utilities.py
+++ b/src/ai4gd_momconnect_haystack/utilities.py
@@ -1,5 +1,4 @@
 import json
-import argparse
 import logging
 from typing import Any
 from pathlib import Path
@@ -43,9 +42,10 @@ def load_json_and_validate(
             return raw_data
 
         # If the model is a Pydantic model, proceed with validation.
-        if isinstance(raw_data, list):
-            return [model.model_validate(item) for item in raw_data]
-        return model.model_validate(raw_data)
+        if issubclass(model, BaseModel):
+            if isinstance(raw_data, list):
+                return [model.model_validate(item) for item in raw_data]
+            return model.model_validate(raw_data)
 
     except FileNotFoundError:
         logging.error(f"File not found: {file_path}")
@@ -67,34 +67,3 @@ def save_json_file(data: list[dict[str, Any]], file_path: Path) -> None:
     except Exception as e:
         logging.error(f"An unexpected error occurred while writing to {file_path}: {e}")
 
-
-def parse_arguments() -> argparse.Namespace:
-    """Parses command-line arguments."""
-    parser = argparse.ArgumentParser(
-        description="Score assessments from a simulation run."
-    )
-    parser.add_argument(
-        "--doc-store-dma",
-        type=Path,
-        required=True,
-        help="Path to the DMA JSON doc store file.",
-    )
-    parser.add_argument(
-        "--doc-store-kab",
-        type=Path,
-        required=True,
-        help="Path to the KAB JSON doc store file.",
-    )
-    parser.add_argument(
-        "--results",
-        type=Path,
-        required=True,
-        help="Path to the raw simulation output JSON file.",
-    )
-    parser.add_argument(
-        "--output",
-        type=Path,
-        default=Path("final_augmented_output.json"),
-        help="Path for the final output file.",
-    )
-    return parser.parse_args()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -4,7 +4,7 @@ from ai4gd_momconnect_haystack.tasks import (
     get_assessment_question,
     _score_and_format_turn,
     _calculate_assessment_score_range,
-    score_assessment_from_simulation
+    score_assessment_from_simulation,
 )
 
 # --- Test Data Fixtures ---
@@ -128,7 +128,7 @@ def test_score_and_format_turn(
 ):
     """Tests various scenarios for scoring a single turn using parametrization."""
     question_lookup = {q["question_number"]: q for q in mock_assessment_questions}
-    
+
     _score_and_format_turn(turn_input, question_lookup)
 
     assert turn_input["score"] == expected_score
@@ -143,6 +143,7 @@ def test_score_assessment_from_simulation_end_to_end(
 ):
     """Tests the full scoring process and the new output format."""
     import copy
+
     simulation_output_copy = copy.deepcopy(mock_simulation_output)
 
     result = score_assessment_from_simulation(

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -141,8 +141,8 @@ def test_score_assessment_from_simulation_end_to_end(
     assert result["assessment_max_score"] == 4
     assert result["score_percentage"] == 50.0
 
-    # Check that the final output has a clean 'results' list
-    results_list = result["results"]
+    # Check that the final output has a clean 'turns' list
+    results_list = result["turns"]
     assert len(results_list) == 3
     assert results_list[0]["score"] == 2
     assert results_list[1]["score"] == 0  # Score defaults to 0 for invalid answers

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,5 +1,182 @@
+import pytest
 from unittest import mock
-from ai4gd_momconnect_haystack.tasks import get_assessment_question
+from ai4gd_momconnect_haystack.tasks import (
+    get_assessment_question,
+    _score_and_format_turn,
+    _calculate_assessment_score_range,
+    score_assessment_from_simulation
+)
+
+# --- Test Data Fixtures ---
+
+
+@pytest.fixture
+def mock_assessment_questions():
+    """Provides a sample list of assessment questions for scoring tests."""
+    return [
+        {
+            "question_number": 1,
+            "question_name": "confident_in_making_health_decisions",
+            "content": "Can you make decisions?",
+            "valid_responses": {"No": 0, "A little": 1, "Yes": 2},
+        },
+        {
+            "question_number": 2,
+            "question_name": "confident_in_talking_to_health_worker",
+            "content": "Can you talk to a worker?",
+            "valid_responses": {"No": 0, "A little": 1, "Yes": 2},
+        },
+        {
+            "question_number": 3,
+            "question_name": "has_invalid_score_value",
+            "content": "This question has a bad score value.",
+            "valid_responses": {"Yes": "two", "No": 0},  # Contains an invalid score
+        },
+        {
+            "question_number": 4,
+            "question_name": "no_valid_responses",
+            "content": "This question has no score options.",
+        },
+    ]
+
+
+@pytest.fixture
+def mock_simulation_output():
+    """Provides a sample simulation output for scoring tests."""
+    return [
+        {
+            "flow_type": "dma_assessment",
+            "turns": [
+                # Valid turn
+                {"question_name": 1, "llm_extracted_user_response": "Yes"},
+                # Answer not in options
+                {"question_name": 2, "llm_extracted_user_response": "Maybe"},
+                # Question number doesn't exist in master file
+                {"question_name": 99, "llm_extracted_user_response": "Yes"},
+                # Malformed turn (missing identifier)
+                {
+                    "some_other_key": "value",
+                    "llm_extracted_user_response": "Yes",
+                },
+            ],
+        }
+    ]
+
+
+@pytest.fixture
+def mock_dma_flow_for_get_question():
+    """Provides a minimal DMA flow for get_assessment_question tests."""
+    return [
+        {"question_number": 1, "content": "Q1"},
+        {"question_number": 2, "content": "Q2"},
+        {"question_number": 3, "content": "Q3"},
+        {"question_number": 4, "content": "Q4"},
+        {"question_number": 5, "content": "Q5"},
+    ]
+
+
+# --- Tests for the scoring logic ---
+
+
+def test_calculate_assessment_score_range(mock_assessment_questions):
+    """Tests the calculation of min and max possible scores."""
+    min_score, max_score = _calculate_assessment_score_range(mock_assessment_questions)
+    # Question 1: min 0, max 2
+    # Question 2: min 0, max 2
+    # Question 3: min 0, max 0 (only "No" is a valid int)
+    # Question 4: min 0, max 0 (no score options)
+    # Total min: 0, Total max: 4
+    assert min_score == 0
+    assert max_score == 4
+
+
+@pytest.mark.parametrize(
+    "turn_input, expected_score, expected_error_substring",
+    [
+        ({"question_name": 1, "llm_extracted_user_response": "Yes"}, 2, None),
+        (
+            {"question_name": 2, "llm_extracted_user_response": "Maybe"},
+            None,
+            "not a valid, scorable option",
+        ),
+        (
+            {"question_name": 99, "llm_extracted_user_response": "Yes"},
+            None,
+            "Question not found",
+        ),
+        (
+            {"llm_extracted_user_response": "Yes"},
+            None,
+            "missing its question identifier",
+        ),
+        (
+            {"question_name": 3, "llm_extracted_user_response": "Yes"},
+            None,
+            "Invalid score value",
+        ),
+    ],
+    ids=[
+        "success",
+        "answer_not_in_options",
+        "question_not_found",
+        "missing_identifier",
+        "invalid_score_value",
+    ],
+)
+def test_score_and_format_turn(
+    turn_input, expected_score, expected_error_substring, mock_assessment_questions
+):
+    """Tests various scenarios for scoring a single turn using parametrization."""
+    question_lookup = {q["question_number"]: q for q in mock_assessment_questions}
+    
+    _score_and_format_turn(turn_input, question_lookup)
+
+    assert turn_input["score"] == expected_score
+    if expected_error_substring:
+        assert expected_error_substring in turn_input["score_error"]
+    else:
+        assert turn_input["score_error"] is None
+
+
+def test_score_assessment_from_simulation_end_to_end(
+    mock_simulation_output, mock_assessment_questions
+):
+    """Tests the full scoring process and the new output format."""
+    import copy
+    simulation_output_copy = copy.deepcopy(mock_simulation_output)
+
+    result = score_assessment_from_simulation(
+        simulation_output=simulation_output_copy,
+        assessment_id="dma_assessment",
+        assessment_questions=mock_assessment_questions,
+    )
+
+    assert result is not None
+    assert result["overall_score"] == 2
+    assert result["assessment_min_score"] == 0
+    assert result["assessment_max_score"] == 4
+    assert result["score_percentage"] == 50.0
+
+    # Check that original turns are present and augmented
+    results_list = result["results"]
+    assert len(results_list) == 4
+    assert results_list[0]["score"] == 2
+    assert results_list[1]["score"] is None
+
+
+def test_score_assessment_from_simulation_no_valid_run(mock_assessment_questions):
+    """Tests that the function returns None if the assessment_id is not found."""
+    simulation_output_missing_flow = [{"flow_type": "onboarding", "turns": []}]
+
+    result = score_assessment_from_simulation(
+        simulation_output=simulation_output_missing_flow,
+        assessment_id="dma_assessment",
+        assessment_questions=mock_assessment_questions,
+    )
+    assert result is None
+
+
+# --- Tests for the question fetching logic ---
 
 
 @mock.patch("ai4gd_momconnect_haystack.tasks.pipelines")


### PR DESCRIPTION
**PR Summary: Add Batch Scoring and Reporting to Simulation Runner**

**What this PR does**

This PR introduces a robust and scalable batch scoring feature that processes simulation outputs. After a simulation completes, this new logic calculates detailed scores for all applicable assessments and augments the original output with a full scoring report, including total scores, percentages, and min/max ranges.

**Key Changes**

- **New Scoring Functions (`tasks.py`):**
  - `score_assessment_from_simulation`: The main orchestration function that takes a simulation output and an assessment_id to produce a final score report.
  - `_score_and_format_turn`: A helper function that processes a single conversational turn, adding score and error data directly to it.
  - `_calculate_assessment_score_range`: A utility that dynamically calculates the minimum and maximum possible scores for any given assessment.

- **Updated Simulation Runner (`main`):**
  - The main function now orchestrates the scoring process after the simulation finishes.
  - It uses a scalable mapping (`scorable_assessments_map`) to identify and score multiple different assessment types (e.g., dma_assessment, knowledge-assessment).
  - The final output is a single, augmented JSON object containing the original simulation data enriched with the scoring results.

- **Comprehensive Pytest Suite (`test_tasks.py`):**
  - Adds a full test suite for the new scoring logic.
  - Uses `pytest.mark.parametrize` for concise and readable testing of various success and failure scenarios.
  - Validates the new, detailed scoring output, including `user_total_score`, percentages, and min/max ranges.

This feature decouples the simulation from the analysis, allowing for flexible and robust post-processing of assessment results.


Ouput example [need to fix the mapping part]: 
[run_output_with_scores.json](https://github.com/user-attachments/files/20709786/run_output_with_scores.json)
