### PR TITLE
Handle empty context for other context fields

### DIFF
--- a/src/ai4gd_momconnect_haystack/tasks.py
+++ b/src/ai4gd_momconnect_haystack/tasks.py
@@ -122,7 +122,7 @@ def extract_onboarding_data_from_response(
                 user_context[k] = v
                 logger.info(f"Updated user_context for {k}: {v}")
             else:
-                user_context["other"][k] = v
+                user_context.setdefault("other", {})[k] = v
     else:
         logger.warning("Data extraction pipeline did not produce a result.")
     return user_context

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -289,7 +289,7 @@ def test_extract_onboarding_data_from_response_updates_context(
     extracted from the user's response.
     """
     # The initial state of the user context
-    user_context = {"other": {}}
+    user_context = {}
 
     # The data that the mocked pipeline will "extract"
     mock_extracted_data = {


### PR DESCRIPTION
Currently there's an assumption that the user context dictionary has an "other" field, and the value of that field is a dictionary.

Since in the API we default to an empty dictionary with no "other" fields, it's best if we don't make that assumption, and instead add the "other" field only when we need to add something to it.
