### PR TITLE
Fix assessment ordering issue

### DIFF
--- a/src/ai4gd_momconnect_haystack/api.py
+++ b/src/ai4gd_momconnect_haystack/api.py
@@ -150,24 +150,23 @@ def assessment(request: AssessmentRequest, token: str = Depends(verify_token)):
     if intent == "JOURNEY_RESPONSE" and request.user_input:
         answer = validate_assessment_answer(
             user_response=request.user_input,
-            current_question_number=request.question_number - 1,
+            question_number=request.question_number,
             current_flow_id=request.flow_id,
         )
-        current_question_number = answer["current_assessment_step"]
+        next_question_number = answer["next_question_number"]
     else:
-        current_question_number = request.question_number
+        next_question_number = request.question_number
 
     question = get_assessment_question(
         flow_id=request.flow_id,
-        current_assessment_step=current_question_number,
+        question_number=next_question_number,
         user_context=request.user_context,
     )
-    contextualized_question = question["contextualized_question"] or ""
-    current_question_number = question["current_question_number"]
+    contextualized_question = question.get("contextualized_question") or ""
     chat_history.append(f"System to User: {contextualized_question}")
     return AssessmentResponse(
         question=contextualized_question,
-        next_question=current_question_number,
+        next_question=next_question_number,
         chat_history=chat_history,
         intent=intent,
         intent_related_response=intent_related_response,

--- a/src/ai4gd_momconnect_haystack/main.py
+++ b/src/ai4gd_momconnect_haystack/main.py
@@ -195,40 +195,37 @@ def run_simulation():
 
     if sim_dma:
         logger.info("\n--- Simulating DMA ---")
-        current_assessment_step = 0
         user_context["goal"] = "Complete the assessment"
         max_assessment_steps = 10  # Safety break
+        question_number = 1
 
         # Simulate Assessment
-        while current_assessment_step < max_assessment_steps:
+        for _ in range(max_assessment_steps):
             print("-" * 20)
-            logger.info(
-                f"Assessment Step: Requesting step after {current_assessment_step}"
-            )
+            logger.info(f"Assessment Step: Requesting question {question_number}")
 
             result = tasks.get_assessment_question(
                 flow_id="dma-assessment",
-                current_assessment_step=current_assessment_step,
+                question_number=question_number,
                 user_context=user_context,
             )
             if not result:
                 logger.info("Assessment flow complete.")
                 break
             contextualized_question = result["contextualized_question"]
-            current_assessment_step = result["current_question_number"]
 
             # Simulate User Response
             user_response = input(contextualized_question + "\n> ")
 
             result = tasks.validate_assessment_answer(
-                user_response, current_assessment_step, "dma-assessment"
+                user_response, question_number, "dma-assessment"
             )
             if not result:
                 logger.warning(
-                    f"Response validation failed for step {current_assessment_step}."
+                    f"Response validation failed for question {question_number}."
                 )
                 continue
-            current_assessment_step = result["current_assessment_step"]
+            question_number = result["next_question_number"]
 
     # ** KAB Scenario **
     print("")
@@ -249,40 +246,37 @@ def run_simulation():
             "behaviour-pre-assessment",
         ]:
             logger.info("\n--- Simulating KAB ---")
-            current_assessment_step = 0
+            question_number = 1
             user_context["goal"] = "Complete the assessment"
             max_assessment_steps = 20  # Safety break
 
             # Simulate Assessments
-            while current_assessment_step < max_assessment_steps:
+            for _ in range(max_assessment_steps):
                 print("-" * 20)
-                logger.info(
-                    f"Assessment Step: Requesting step after {current_assessment_step}"
-                )
+                logger.info(f"Assessment Step: Requesting question {question_number}")
 
                 result = tasks.get_assessment_question(
                     flow_id=flow_id,
-                    current_assessment_step=current_assessment_step,
+                    question_number=question_number,
                     user_context=user_context,
                 )
                 if not result:
                     logger.info("Assessment flow complete.")
                     break
                 contextualized_question = result["contextualized_question"]
-                current_assessment_step = result["current_question_number"]
 
                 # Simulate User Response
                 user_response = input(contextualized_question + "\n> ")
 
                 result = tasks.validate_assessment_answer(
-                    user_response, current_assessment_step, flow_id
+                    user_response, question_number, flow_id
                 )
                 if not result:
                     logger.warning(
-                        f"Response validation failed for step {current_assessment_step}."
+                        f"Response validation failed for question {question_number}."
                     )
                     continue
-                current_assessment_step = result["current_assessment_step"]
+                question_number = result["next_question_number"]
 
     # ** ANC Survey Scenario **
     print("")

--- a/src/ai4gd_momconnect_haystack/pipelines.py
+++ b/src/ai4gd_momconnect_haystack/pipelines.py
@@ -1,14 +1,14 @@
-import logging
 import json
+import logging
 from functools import cache
 from typing import Any
 
 from haystack import Pipeline
 from haystack.components.builders.chat_prompt_builder import ChatPromptBuilder
-from haystack.dataclasses import ChatMessage
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.components.retrievers import FilterRetriever
 from haystack.components.validators import JsonSchemaValidator
+from haystack.dataclasses import ChatMessage
 from haystack.tools import Tool
 from haystack.utils import Secret
 
@@ -1110,7 +1110,7 @@ def run_assessment_response_validator_pipeline(
 
         llm_response = result.get("llm", {})
         if llm_response and llm_response.get("replies"):
-            validated_text = llm_response["replies"][0].text.strip()
+            validated_text = llm_response["replies"][0].text.strip().strip('"')
             if validated_text.lower() == "nonsense":
                 return None
             if validated_text in valid_responses:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -179,12 +179,11 @@ def test_get_assessment_question(pipelines_mock):
     )
     result = get_assessment_question(
         flow_id="dma-assessment",
-        current_assessment_step=0,
+        question_number=1,
         user_context={},
     )
     assert result == {
         "contextualized_question": "mock_question",
-        "current_question_number": 1,
     }
 
 
@@ -195,16 +194,15 @@ def test_get_last_assessment_question(pipelines_mock):
     )
     result = get_assessment_question(
         flow_id="dma-assessment",
-        current_assessment_step=4,
+        question_number=4,
         user_context={},
     )
     assert result == {
         "contextualized_question": "mock_question",
-        "current_question_number": 5,
     }
     result = get_assessment_question(
         flow_id="dma-assessment",
-        current_assessment_step=5,
+        question_number=5,
         user_context={},
     )
     assert result == {}
@@ -217,7 +215,7 @@ def test_get_assessment_question_invalid_flow(pipelines_mock):
     """
     result = get_assessment_question(
         flow_id="non-existent-flow",
-        current_assessment_step=0,
+        question_number=1,
         user_context={},
     )
     assert result == {}
@@ -236,13 +234,13 @@ def test_validate_assessment_answer_success(pipelines_mock):
 
     result = validate_assessment_answer(
         user_response="This is my answer.",
-        current_question_number=3,
+        question_number=3,
         current_flow_id="dma-assessment",
     )
 
     assert result == {
         "processed_user_response": mock_processed_response,
-        "current_assessment_step": 3,
+        "next_question_number": 4,
     }
 
 
@@ -255,14 +253,14 @@ def test_validate_assessment_answer_failure(pipelines_mock):
 
     result = validate_assessment_answer(
         user_response="I don't know.",
-        current_question_number=3,
+        question_number=3,
         current_flow_id="dma-assessment",
     )
 
-    # Check that the response is None and the step is decremented to repeat the question
+    # Check that the response is None and the question number is kept the same to repeat the question
     assert result == {
         "processed_user_response": None,
-        "current_assessment_step": 2,
+        "next_question_number": 3,
     }
 
 


### PR DESCRIPTION
Currently the assessment doesn't go from one question to another properly. The code is also a bit difficult to understand what is going on.

In order to address this, I did a few things:
- Only the validate response function should advance the question number, since only if the response is valid should we advance to the next question, so the contextualise question function no longer returns the question number, since it shouldn't update it
- I've renamed some of the function arguments and return values, to make it clearer what they are referring to
- I've added in the doc strings where we're using 1-based indexing.
