### PR TITLE
Fix to ensure we ask the last question of the assessment

### DIFF
--- a/src/ai4gd_momconnect_haystack/tasks.py
+++ b/src/ai4gd_momconnect_haystack/tasks.py
@@ -142,7 +142,7 @@ def get_assessment_question(
         logger.error(f"Invalid flow_id provided: '{flow_id}'. No questions found.")
         return {}
 
-    if question_number >= len(question_list):
+    if question_number > len(question_list):
         logger.info(f"Assessment flow '{flow_id}' complete.")
         return {}
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -194,7 +194,7 @@ def test_get_last_assessment_question(pipelines_mock):
     )
     result = get_assessment_question(
         flow_id="dma-assessment",
-        question_number=4,
+        question_number=5,
         user_context={},
     )
     assert result == {
@@ -202,7 +202,7 @@ def test_get_last_assessment_question(pipelines_mock):
     }
     result = get_assessment_question(
         flow_id="dma-assessment",
-        question_number=5,
+        question_number=6,
         user_context={},
     )
     assert result == {}


### PR DESCRIPTION
There's an off-by-one where we check if we've reached the end of the assessments. Since the question numbers are 1-based, when comparing to the number of questions, we should use > not >=
