### PR TITLE
Implementing assessment scoring, skip thresholds and end-of-assessment messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,46 @@ for example:
 }
 ```
 
+### End of pre-assessment journeys
+A short thank you and feedback journey is handled through the `/v1/assessment-end` endpoint. It receives a POST request with a JSON body, with the following fields:
+
+`user_id`: A unique identifier for a user, as a string
+
+`flow_id`: Which assessment this is for. This can be one of `dma-pre-assessment`, `knowledge-pre-assessment`, `behaviour-pre-assessment`, `attitude-pre-assessment`
+
+`user_input`: The message that the user sent to us, as a string
+
+for example:
+```json
+{
+  "user_id": "1234",
+  "flow_id": "dma-pre-assessment",
+  "user_input": "I am 20 weeks pregnant",
+}
+```
+
+The API will respond with the following fields:
+
+`message`: The next message to send to the user, as a string. If the journey is complete, this may contain a final thank you message.
+
+`task`: (optional) a task that needs to be performed by Turn. This can be one of:
+- `REMIND_ME_LATER`: set a reminder to reengage the user in 24 hours.
+- `STORE_FEEDBACK`: save a flow result containing validated feedback shared by the user.
+
+`intent`: (optional) the user's intent. See the ["Intents"](#intents) section for more info.
+
+`intent_related_response`: (optional) a response related to the user's intent. See the ["Intents"](#intents) section for more info.
+
+for example:
+```json
+{
+  "message": "Thank you for answering these questions!",
+  "task": "",
+  "intent": "JOURNEY_RESPONSE",
+  "intent_related_response": null
+}
+```
+
 ## Linting
 Run the following commands from the root directory:
 - `uv run ruff check --fix`

--- a/src/ai4gd_momconnect_haystack/doc_store.py
+++ b/src/ai4gd_momconnect_haystack/doc_store.py
@@ -32,6 +32,8 @@ ONBOARDING_FLOW = read_json(data_dir / "onboarding.json")
 # Assessment Questions Data
 DMA_FLOW = read_json(data_dir / "dma.json")
 KAB_FLOW = read_json(data_dir / "kab.json")
+# Assessment End Messaging Data
+ASSESSMENT_END_FLOW = read_json(data_dir / "assessment_ends.json")
 
 # ANC Follow-Up Questions Data
 ANC_SURVEY_FLOW = read_json(data_dir / "anc_survey.json")

--- a/src/ai4gd_momconnect_haystack/doc_store.py
+++ b/src/ai4gd_momconnect_haystack/doc_store.py
@@ -1,4 +1,5 @@
 import logging
+import json
 from os import environ
 from pathlib import Path
 from typing import Any
@@ -12,9 +13,16 @@ from haystack_integrations.document_stores.weaviate import (
     AuthApiKey,
     WeaviateDocumentStore,
 )
+from pydantic import TypeAdapter, ValidationError
 from weaviate.embedded import EmbeddedOptions
 
-from .utilities import read_json
+from ai4gd_momconnect_haystack.pydantic_models import (
+    FAQ,
+    ANCSurveyQuestion,
+    AssessmentEndItem,
+    AssessmentQuestion,
+    OnboardingQuestion,
+)
 
 # --- Configurations ---
 load_dotenv()
@@ -25,21 +33,139 @@ embedding_model_name = "text-embedding-3-small"
 
 
 # --- Data ---
-# Onboarding Flows Data
+def load_content_json_and_validate(
+    file_path: Path, model: object, flow_id: str
+) -> list | None:
+    """
+    Loads a JSON file and validates its content against a Pydantic model.
+    This is the primary gateway for safely loading any external JSON data.
+    """
+    try:
+        with file_path.open("r", encoding="utf-8") as f:
+            raw_data = json.load(f)
+
+        items_to_validate = raw_data.get(flow_id)
+        if items_to_validate is None:
+            logging.error(f"Flow ID '{flow_id}' not found in {file_path}")
+            return None
+
+        if not isinstance(items_to_validate, list):
+            logging.error(
+                f"Expected a list for flow_id '{flow_id}' in {file_path}, "
+                f"but got {type(items_to_validate).__name__}"
+            )
+            return None
+
+        list_adapter = TypeAdapter(list[model])  # type: ignore[valid-type]
+
+        return list_adapter.validate_python(items_to_validate)
+
+    except FileNotFoundError:
+        logging.error(f"File not found: {file_path}")
+    except ValidationError as e:
+        logging.error(
+            f"Data validation error in {file_path} for flow '{flow_id}':\n{e}"
+        )
+    except json.JSONDecodeError:
+        logging.error(f"Could not decode JSON from {file_path}")
+    except Exception as e:
+        logging.error(f"An unexpected error occurred with {file_path}: {e}")
+
+    return None
+
+
 data_dir = Path("src/ai4gd_momconnect_haystack/static_content")
-ONBOARDING_FLOW = read_json(data_dir / "onboarding.json")
+
+# Onboarding Flows Data
+onboarding_flow = load_content_json_and_validate(
+    data_dir / "onboarding.json", OnboardingQuestion, "onboarding"
+)
+assert onboarding_flow is not None, "Failed to load the onboarding flow."
+ONBOARDING_FLOW: list[OnboardingQuestion] = onboarding_flow
 
 # Assessment Questions Data
-DMA_FLOW = read_json(data_dir / "dma.json")
-KAB_FLOW = read_json(data_dir / "kab.json")
+dma_flow = load_content_json_and_validate(
+    data_dir / "dma.json", AssessmentQuestion, "dma-assessment"
+)
+assert dma_flow is not None, "Failed to load the DMA flow."
+DMA_FLOW: list[AssessmentQuestion] = dma_flow
+
+kab_k_flow = load_content_json_and_validate(
+    data_dir / "kab.json", AssessmentQuestion, "knowledge-assessment"
+)
+assert kab_k_flow is not None, "Failed to load the KAB Knowledge flow."
+KAB_K_FLOW: list[AssessmentQuestion] = kab_k_flow
+
+kab_a_flow = load_content_json_and_validate(
+    data_dir / "kab.json", AssessmentQuestion, "attitude-assessment"
+)
+assert kab_a_flow is not None, "Failed to load the KAB Attitude flow."
+KAB_A_FLOW: list[AssessmentQuestion] = kab_a_flow
+
+kab_b_pre_flow = load_content_json_and_validate(
+    data_dir / "kab.json", AssessmentQuestion, "behaviour-pre-assessment"
+)
+assert kab_b_pre_flow is not None, "Failed to load the KAB Behaviour (pre) flow."
+KAB_B_PRE_FLOW: list[AssessmentQuestion] = kab_b_pre_flow
+
+kab_b_post_flow = load_content_json_and_validate(
+    data_dir / "kab.json", AssessmentQuestion, "behaviour-post-assessment"
+)
+assert kab_b_post_flow is not None, "Failed to load the KAB Behaviour (post) flow."
+KAB_B_POST_FLOW: list[AssessmentQuestion] = kab_b_post_flow
+
 # Assessment End Messaging Data
-ASSESSMENT_END_FLOW = read_json(data_dir / "assessment_ends.json")
+dma_assessment_end_flow: list[AssessmentEndItem] | None = (
+    load_content_json_and_validate(
+        data_dir / "assessment_ends.json", AssessmentEndItem, "dma-pre-assessment"
+    )
+)
+assert dma_assessment_end_flow is not None, (
+    "Failed to load the DMA assessment end flow."
+)
+DMA_ASSESSMENT_END_FLOW: list[AssessmentEndItem] = dma_assessment_end_flow
+
+kab_k_assessment_end_flow: list[AssessmentEndItem] | None = (
+    load_content_json_and_validate(
+        data_dir / "assessment_ends.json", AssessmentEndItem, "knowledge-pre-assessment"
+    )
+)
+assert kab_k_assessment_end_flow is not None, (
+    "Failed to load the KAB Knowledge assessment end flow."
+)
+KAB_K_ASSESSMENT_END_FLOW: list[AssessmentEndItem] = kab_k_assessment_end_flow
+
+kab_a_assessment_end_flow: list[AssessmentEndItem] | None = (
+    load_content_json_and_validate(
+        data_dir / "assessment_ends.json", AssessmentEndItem, "attitude-pre-assessment"
+    )
+)
+assert kab_a_assessment_end_flow is not None, (
+    "Failed to load the KAB Attitude assessment end flow."
+)
+KAB_A_ASSESSMENT_END_FLOW: list[AssessmentEndItem] = kab_a_assessment_end_flow
+
+kab_b_assessment_end_flow: list[AssessmentEndItem] | None = (
+    load_content_json_and_validate(
+        data_dir / "assessment_ends.json", AssessmentEndItem, "behaviour-pre-assessment"
+    )
+)
+assert kab_b_assessment_end_flow is not None, (
+    "Failed to load the KAB Behaviour assessment end flow."
+)
+KAB_B_ASSESSMENT_END_FLOW: list[AssessmentEndItem] = kab_b_assessment_end_flow
 
 # ANC Follow-Up Questions Data
-ANC_SURVEY_FLOW = read_json(data_dir / "anc_survey.json")
+anc_survey_flow = load_content_json_and_validate(
+    data_dir / "anc_survey.json", ANCSurveyQuestion, "anc-survey"
+)
+assert anc_survey_flow is not None, "Failed to load the ANC survey flow."
+ANC_SURVEY_FLOW: list[ANCSurveyQuestion] = anc_survey_flow
 
 # FAQ Data
-FAQ_DATA = read_json(data_dir / "faqs.json")
+faq_data = load_content_json_and_validate(data_dir / "faqs.json", FAQ, "faqs")
+assert faq_data is not None, "Failed to load the FAQs."
+FAQ_DATA: list[FAQ] = faq_data
 
 
 # --- Core Functions ---
@@ -88,8 +214,8 @@ def create_embedding_pipeline(doc_store: WeaviateDocumentStore) -> Pipeline:
     return indexing_pipeline
 
 
-def ingest_content(
-    indexing_pipeline: Pipeline, content_flows: dict[str, list[dict[str, Any]]]
+def ingest_onboarding_content(
+    indexing_pipeline: Pipeline, content: list[OnboardingQuestion], flow_id: str
 ):
     """
     Processes content data, converts to Haystack Documents, and ingests them
@@ -97,67 +223,144 @@ def ingest_content(
 
     Args:
         indexing_pipeline: The Haystack pipeline for embedding and writing.
-        content_flows: A dictionary where keys are flow_ids and values are lists
-                       of content dictionaries (like ONBOARDING_FLOW or DMA_FLOW).
+        content: A list of OnboardingQuestion objects.
     """
     documents_to_ingest: list[Document] = []
-    flow_count = 0
     doc_count = 0
 
-    for flow_id, content_pieces in content_flows.items():
-        print("INGESTING", flow_id)
-        flow_count += 1
-        for piece in content_pieces:
-            doc_count += 1
-            if flow_id == "anc-survey":
-                doc = Document(
-                    content=piece["content"],
-                    meta={
-                        "flow_id": flow_id,
-                        "title": piece["title"],
-                        "content_type": piece["content_type"],
-                        "valid_responses": piece.get("valid_responses", []),
-                    },
-                )
-            elif flow_id == "faqs":
-                doc = Document(
-                    content=piece["content"],
-                    meta={
-                        "flow_id": flow_id,
-                        "title": piece["title"],
-                        "valid_responses": piece.get("valid_responses", []),
-                    },
-                )
-            elif flow_id == "onboarding":
-                doc = Document(
-                    content=piece["content"],
-                    meta={
-                        "flow_id": flow_id,
-                        "question_number": piece["question_number"],
-                        "content_type": piece["content_type"],
-                        "valid_responses": piece.get("valid_responses", []),
-                    },
-                )
-            else:
-                # For DMA and KAB flows
-                doc = Document(
-                    content=piece["content"],
-                    meta={
-                        "flow_id": flow_id,
-                        "question_number": piece["question_number"],
-                        "content_type": piece["content_type"],
-                        "valid_responses": [
-                            item["response"]
-                            for item in piece.get("valid_responses_and_scores", [])
-                        ],
-                    },
-                )
-            documents_to_ingest.append(doc)
+    print("INGESTING", flow_id)
+    for piece in content:
+        doc_count += 1
+        doc = Document(
+            content=piece.content,
+            meta={
+                "flow_id": flow_id,
+                "question_number": piece.question_number,
+                "content_type": piece.content_type,
+                "valid_responses": piece.valid_responses,
+            },
+        )
+        documents_to_ingest.append(doc)
 
     if documents_to_ingest:
-        logger.info(
-            f"Starting ingestion of {doc_count} documents from {flow_count} flows..."
+        logger.info(f"Starting ingestion of {doc_count} documents...")
+        indexing_pipeline.run({"embedder": {"documents": documents_to_ingest}})
+        logger.info(f"Successfully ingested {doc_count} documents.")
+    else:
+        logger.warning("No documents found to ingest.")
+
+
+def ingest_assessment_content(
+    indexing_pipeline: Pipeline, content: list[AssessmentQuestion], flow_id: str
+):
+    """
+    Processes content data, converts to Haystack Documents, and ingests them
+    into the document store using the provided indexing pipeline.
+
+    Args:
+        indexing_pipeline: The Haystack pipeline for embedding and writing.
+        content: A list of AssessmentQuestion objects.
+    """
+    documents_to_ingest: list[Document] = []
+    doc_count = 0
+
+    print("INGESTING", flow_id)
+    for piece in content:
+        doc_count += 1
+        if piece.valid_responses_and_scores:
+            doc = Document(
+                content=piece.content,
+                meta={
+                    "flow_id": flow_id,
+                    "question_number": piece.question_number,
+                    "content_type": piece.content_type,
+                    "valid_responses": [
+                        item.response for item in piece.valid_responses_and_scores
+                    ],
+                },
+            )
+        else:
+            doc = Document(
+                content=piece.content,
+                meta={
+                    "flow_id": flow_id,
+                    "question_number": piece.question_number,
+                    "content_type": piece.content_type,
+                    "valid_responses": [],
+                },
+            )
+        documents_to_ingest.append(doc)
+
+    if documents_to_ingest:
+        logger.info(f"Starting ingestion of {doc_count} documents...")
+        indexing_pipeline.run({"embedder": {"documents": documents_to_ingest}})
+        logger.info(f"Successfully ingested {doc_count} documents.")
+    else:
+        logger.warning("No documents found to ingest.")
+
+
+def ingest_survey_content(
+    indexing_pipeline: Pipeline, content: list[ANCSurveyQuestion], flow_id: str
+):
+    """
+    Processes content data, converts to Haystack Documents, and ingests them
+    into the document store using the provided indexing pipeline.
+
+    Args:
+        indexing_pipeline: The Haystack pipeline for embedding and writing.
+        content: A list of ANCSurveyQuestion objects.
+    """
+    documents_to_ingest: list[Document] = []
+    doc_count = 0
+
+    print("INGESTING", flow_id)
+    for piece in content:
+        doc_count += 1
+        doc = Document(
+            content=piece.content,
+            meta={
+                "flow_id": flow_id,
+                "title": piece.title,
+                "content_type": piece.content_type,
+                "valid_responses": piece.valid_responses,
+            },
         )
+        documents_to_ingest.append(doc)
+
+    if documents_to_ingest:
+        logger.info(f"Starting ingestion of {doc_count} documents...")
+        indexing_pipeline.run({"embedder": {"documents": documents_to_ingest}})
+        logger.info(f"Successfully ingested {doc_count} documents.")
+    else:
+        logger.warning("No documents found to ingest.")
+
+
+def ingest_faq_content(indexing_pipeline: Pipeline, content: list[FAQ], flow_id: str):
+    """
+    Processes content data, converts to Haystack Documents, and ingests them
+    into the document store using the provided indexing pipeline.
+
+    Args:
+        indexing_pipeline: The Haystack pipeline for embedding and writing.
+        content: A list of FAQ objects.
+    """
+    documents_to_ingest: list[Document] = []
+    doc_count = 0
+
+    print("INGESTING", flow_id)
+    for piece in content:
+        doc_count += 1
+        doc = Document(
+            content=piece.content,
+            meta={
+                "flow_id": flow_id,
+                "title": piece.title,
+            },
+        )
+        documents_to_ingest.append(doc)
+
+    if documents_to_ingest:
+        logger.info(f"Starting ingestion of {doc_count} documents...")
         indexing_pipeline.run({"embedder": {"documents": documents_to_ingest}})
         logger.info(f"Successfully ingested {doc_count} documents.")
     else:
@@ -165,8 +368,8 @@ def ingest_content(
 
 
 def get_remaining_onboarding_questions(
-    user_context: dict[str, Any], all_onboarding_questions: list[dict[str, Any]]
-) -> list[dict[str, Any]]:
+    user_context: dict[str, Any], all_onboarding_questions: list[OnboardingQuestion]
+) -> list[OnboardingQuestion]:
     """
     Identifies which onboarding questions still need to be asked based on user_context.
     """
@@ -186,7 +389,7 @@ def get_remaining_onboarding_questions(
     ]
     remaining_questions = []
     for question_data in all_onboarding_questions:
-        if question_data.get("collects") not in collected_data_points:
+        if question_data.collects not in collected_data_points:
             remaining_questions.append(question_data)
     return remaining_questions
 
@@ -211,14 +414,21 @@ def setup_document_store() -> WeaviateDocumentStore:
         logger.info("Document store is empty. Proceeding with ingestion.")
         indexing_pipe = create_embedding_pipeline(document_store)
         logger.info("--- Ingesting Onboarding Content ---")
-        ingest_content(indexing_pipe, ONBOARDING_FLOW)
+        ingest_onboarding_content(indexing_pipe, ONBOARDING_FLOW, "onboarding")
         logger.info("--- Ingesting Assessment Content ---")
-        ingest_content(indexing_pipe, DMA_FLOW)
-        ingest_content(indexing_pipe, KAB_FLOW)
+        ingest_assessment_content(indexing_pipe, DMA_FLOW, "dma-assessment")
+        ingest_assessment_content(indexing_pipe, KAB_K_FLOW, "knowledge-assessment")
+        ingest_assessment_content(indexing_pipe, KAB_A_FLOW, "attitude-assessment")
+        ingest_assessment_content(
+            indexing_pipe, KAB_B_PRE_FLOW, "behaviour-pre-assessment"
+        )
+        ingest_assessment_content(
+            indexing_pipe, KAB_B_POST_FLOW, "behaviour-post-assessment"
+        )
         logger.info("--- Ingesting ANC Survey Content ---")
-        ingest_content(indexing_pipe, ANC_SURVEY_FLOW)
+        ingest_survey_content(indexing_pipe, ANC_SURVEY_FLOW, "anc-survey")
         logger.info("--- Ingesting FAQ Content ---")
-        ingest_content(indexing_pipe, FAQ_DATA)
+        ingest_faq_content(indexing_pipe, FAQ_DATA, "faqs")
     else:
         logger.info(
             "Documents found in the store. Skipping ingestion to avoid duplicates."

--- a/src/ai4gd_momconnect_haystack/enums.py
+++ b/src/ai4gd_momconnect_haystack/enums.py
@@ -1,0 +1,17 @@
+from enum import Enum
+
+
+class AssessmentType(str, Enum):
+    dma_pre_assessment = "dma-pre-assessment"
+    dma_post_assessment = "dma-post-assessment"
+    knowledge_pre_assessment = "knowledge-pre-assessment"
+    knowledge_post_assessment = "knowledge-post-assessment"
+    attitude_pre_assessment = "attitude-pre-assessment"
+    attitude_post_assessment = "attitude-post-assessment"
+    behaviour_pre_assessment = "behaviour-pre-assessment"
+    behaviour_post_assessment = "behaviour-post-assessment"
+
+
+class HistoryType(str, Enum):
+    anc = "anc"
+    onboarding = "onboarding"

--- a/src/ai4gd_momconnect_haystack/main.py
+++ b/src/ai4gd_momconnect_haystack/main.py
@@ -10,7 +10,7 @@ from haystack.dataclasses import ChatMessage
 from pydantic import ValidationError
 from sqlalchemy import delete
 
-from ai4gd_momconnect_haystack.sqlalchemy_models import PreAssessmentQuestionHistory
+from ai4gd_momconnect_haystack.sqlalchemy_models import AssessmentHistory
 
 from . import tasks
 from .database import AsyncSessionLocal, init_db
@@ -340,13 +340,12 @@ async def run_simulation(gt_scenarios: list[dict[str, Any]] | None = None):
                 logger.info("Assessment flow complete.")
                 break
             contextualized_question = result["contextualized_question"]
-            if "-pre" in flow_id.value:
-                await save_pre_assessment_question(
-                    user_id=user_id,
-                    assessment_type=flow_id,
-                    question_number=question_number,
-                    question=contextualized_question,
-                )
+            await save_assessment_question(
+                user_id=user_id,
+                assessment_type=flow_id,
+                question_number=question_number,
+                question=contextualized_question,
+            )
 
             # Simulate User Response
             ### MODIFIED: Get user_response from GT data or input() ###
@@ -449,9 +448,9 @@ async def run_simulation(gt_scenarios: list[dict[str, Any]] | None = None):
             async with AsyncSessionLocal() as session:
                 async with session.begin():
                     await session.execute(
-                        delete(PreAssessmentQuestionHistory).where(
-                            PreAssessmentQuestionHistory.user_id == user_id,
-                            PreAssessmentQuestionHistory.assessment_id == flow_id.value,
+                        delete(AssessmentHistory).where(
+                            AssessmentHistory.user_id == user_id,
+                            AssessmentHistory.assessment_id == flow_id.value,
                         )
                     )
                     await session.commit()
@@ -517,13 +516,12 @@ async def run_simulation(gt_scenarios: list[dict[str, Any]] | None = None):
                     logger.info("Assessment flow complete.")
                     break
                 contextualized_question = result["contextualized_question"]
-                if "-pre" in flow_id.value:
-                    await save_pre_assessment_question(
-                        user_id=user_id,
-                        assessment_type=flow_id,
-                        question_number=question_number,
-                        question=contextualized_question,
-                    )
+                await save_assessment_question(
+                    user_id=user_id,
+                    assessment_type=flow_id,
+                    question_number=question_number,
+                    question=contextualized_question,
+                )
 
                 # Simulate User Response
                 # Get user_response from GT data or input() #
@@ -625,9 +623,9 @@ async def run_simulation(gt_scenarios: list[dict[str, Any]] | None = None):
                 async with AsyncSessionLocal() as session:
                     async with session.begin():
                         await session.execute(
-                            delete(PreAssessmentQuestionHistory).where(
-                                PreAssessmentQuestionHistory.user_id == user_id,
-                                PreAssessmentQuestionHistory.assessment_id
+                            delete(AssessmentHistory).where(
+                                AssessmentHistory.user_id == user_id,
+                                AssessmentHistory.assessment_id
                                 == flow_id.value,
                             )
                         )

--- a/src/ai4gd_momconnect_haystack/main.py
+++ b/src/ai4gd_momconnect_haystack/main.py
@@ -1,6 +1,7 @@
 import asyncio
-import logging
 from datetime import datetime
+import logging
+import json
 from os import environ
 from pathlib import Path
 from typing import Any
@@ -10,19 +11,30 @@ from haystack.dataclasses import ChatMessage
 from pydantic import ValidationError
 from sqlalchemy import delete
 
-from ai4gd_momconnect_haystack.sqlalchemy_models import AssessmentHistory
+from ai4gd_momconnect_haystack.sqlalchemy_models import (
+    AssessmentEndMessagingHistory,
+    AssessmentHistory,
+    AssessmentResultHistory,
+)
 
 from . import tasks
 from .database import AsyncSessionLocal, init_db
-from .pydantic_models import AssessmentRun
+from .enums import AssessmentType
+from .pydantic_models import (
+    AssessmentEndScoreBasedMessage,
+    AssessmentEndSimpleMessage,
+    AssessmentRun,
+    Turn,
+)
 from .utilities import (
-    AssessmentType,
+    calculate_and_store_assessment_result,
     generate_scenario_id,
-    get_pre_assessment_history,
+    get_assessment_end_messaging_history,
+    get_assessment_result,
     load_json_and_validate,
+    save_assessment_end_message,
     save_json_file,
-    read_json,
-    save_pre_assessment_question,
+    save_assessment_question,
 )
 
 load_dotenv()
@@ -34,8 +46,6 @@ logging.basicConfig(
     level=numeric_level, format="%(asctime)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
-
-# TODO: Add confirmation outputs telling the user what we understood their response to be, before sending them a next message.
 
 # Define fixed file paths for the Docker environment
 DATA_PATH = Path("src/ai4gd_momconnect_haystack/")
@@ -56,11 +66,14 @@ SCORABLE_ASSESSMENTS = {
     "behaviour-pre-assessment",
 }
 
-# TODO: Align simulation prompts with doc_store for valid responses.
-# The prompts used to generate the simulation run (e.g., in contextualization tasks)
-# provide response options like "Not at all confident", "A little confident", etc.
-# However, the doc_store (e.g., dma.json) expects "I strongly disagree", "I agree", etc.
-# for scoring. These must be aligned to ensure correct data extraction and scoring.
+
+def read_json(filepath: Path) -> dict:
+    """Reads JSON data from a file."""
+    try:
+        return json.loads(filepath.read_text(encoding="utf-8"))
+    except Exception as e:
+        logger.error("Error loading JSON from %s: %s", filepath, e)
+        raise
 
 
 async def _get_user_response(
@@ -109,7 +122,6 @@ async def run_simulation(gt_scenarios: list[dict[str, Any]] | None = None):
     logger.info("--- Starting Haystack POC Simulation ---")
     simulation_results = []
 
-    # --- NEW: Pre-process GT data for easy lookup ---
     gt_lookup_by_flow = {}
     if gt_scenarios:
         logger.info("Running in AUTOMATED mode.")
@@ -119,7 +131,6 @@ async def run_simulation(gt_scenarios: list[dict[str, Any]] | None = None):
                 gt_lookup_by_flow[flow_type] = scenario
     else:
         logger.info("Running in INTERACTIVE mode.")
-    # --- END NEW ---
 
     # --- Simulation ---
     # ** Onboarding Scenario **
@@ -194,7 +205,7 @@ async def run_simulation(gt_scenarios: list[dict[str, Any]] | None = None):
             # Keep getting a user response until it is one that continues the journey:
             intent = None
             while intent != "JOURNEY_RESPONSE":
-                ### MODIFIED: Get user_response from GT data or input() ###
+                # Get user_response from GT data or input()
                 print(f"Question #: {question_number}")
                 print(f"Question: {contextualized_question}")
                 user_response = await _get_user_response(
@@ -207,8 +218,8 @@ async def run_simulation(gt_scenarios: list[dict[str, Any]] | None = None):
 
                 if user_response is None:
                     break
-                ### END MODIFIED ###
-                print(f"Use_response: {user_response}")
+
+                print(f"User_response: {user_response}")
                 chat_history.append(ChatMessage.from_user(text=user_response))
 
                 # Classify user's intent and act accordingly
@@ -239,7 +250,6 @@ async def run_simulation(gt_scenarios: list[dict[str, Any]] | None = None):
             if user_response is None:
                 break
 
-            ### Endpoint 2: Turn can call to get extracted data from a user response.
             previous_context = user_context.copy()
             user_context = tasks.extract_onboarding_data_from_response(
                 user_response, user_context, chat_history
@@ -312,6 +322,15 @@ async def run_simulation(gt_scenarios: list[dict[str, Any]] | None = None):
         max_assessment_steps = 10  # Safety break
         question_number = 1
 
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                await session.execute(
+                    delete(AssessmentHistory).where(
+                        AssessmentHistory.user_id == user_id,
+                        AssessmentHistory.assessment_id == flow_id.value,
+                    )
+                )
+
         # Simulate Assessment
         gt_scenario = gt_lookup_by_flow.get(flow_id)
         scenario_id_to_use = (
@@ -344,13 +363,14 @@ async def run_simulation(gt_scenarios: list[dict[str, Any]] | None = None):
                 user_id=user_id,
                 assessment_type=flow_id,
                 question_number=question_number,
+                user_response=None,
                 question=contextualized_question,
+                score=None,
             )
 
             # Simulate User Response
-            ### MODIFIED: Get user_response from GT data or input() ###
+            # Get user_response from GT data or input()
             user_response = ""
-            # Find the specific turn in the GT list by searching for the matching question_number
             print(f"Question #: {question_number}")
             print(f"Question: {contextualized_question}")
             user_response = await _get_user_response(
@@ -362,33 +382,7 @@ async def run_simulation(gt_scenarios: list[dict[str, Any]] | None = None):
             )
             if user_response is None:
                 break
-            print(f"Use_response: {user_response}")
-
-            # Classify user's intent and act accordingly
-            intent, intent_related_response = tasks.handle_user_message(
-                contextualized_question, user_response
-            )
-            # If a question about the study or about health was asked, print the
-            # response that would be sent to users
-            if intent in ["HEALTH_QUESTION", "QUESTION_ABOUT_STUDY"]:
-                print(intent_related_response)
-            elif intent in [
-                "ASKING_TO_STOP_MESSAGES",
-                "ASKING_TO_DELETE_DATA",
-                "REPORTING_AIRTIME_NOT_RECEIVED",
-            ]:
-                print(f"Turn must be notified that user is {intent}")
-            elif intent == "CHITCHAT":
-                print(intent_related_response)
-                print(
-                    (
-                        f"User is chitchatting and needs to still respond to "
-                        f"the previous question: {contextualized_question}"
-                    )
-                )
-            else:
-                # intent must be JOURNEY_RESPONSE
-                pass
+            print(f"User_response: {user_response}")
 
             # Classify user's intent and act accordingly
             intent, intent_related_response = tasks.handle_user_message(
@@ -434,36 +428,295 @@ async def run_simulation(gt_scenarios: list[dict[str, Any]] | None = None):
                 }
             )
             question_number = result["next_question_number"]
-
-        # Inspect the pre-assessment questions that were stored as history,
-        # before deleting them:
-        if "-pre" in flow_id.value:
-            history = await get_pre_assessment_history(user_id, flow_id)
-            if history:
-                logger.info(
-                    "Stored the following pre-assessment questions during simulation:"
+            assessment_questions = tasks.load_and_validate_assessment_questions(
+                tasks.assessment_map_to_their_pre[flow_id.value]
+            )
+            if assessment_questions:
+                question_lookup = {q.question_number: q for q in assessment_questions}
+                score_result = tasks._score_single_turn(
+                    Turn.model_validate(dma_turns[-1]),
+                    question_lookup,
                 )
-                for q in history:
-                    logger.info(f"Question {q.question_number}: {q.question}")
+                await save_assessment_question(
+                    user_id=user_id,
+                    assessment_type=flow_id,
+                    question=None,
+                    question_number=dma_turns[-1]["question_number"],
+                    user_response=processed_user_response,
+                    score=score_result["score"],
+                )
+
+        await calculate_and_store_assessment_result(user_id, flow_id)
+
+        # Start of assessment-end messaging
+        next_message = "placeholder"
+        user_response = ""
+        previous_message: str = ""
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                await session.execute(
+                    delete(AssessmentEndMessagingHistory).where(
+                        AssessmentEndMessagingHistory.user_id == user_id,
+                        AssessmentEndMessagingHistory.assessment_id == flow_id.value,
+                    )
+                )
+        while next_message:
+            assessment_result = await get_assessment_result(user_id, flow_id)
+            if not assessment_result:
+                logger.error(
+                    f"Overall assessment result for {flow_id.value} not found!"
+                )
+                break
+            score_category = assessment_result.category
+            if assessment_result.crossed_skip_threshold:
+                score_category = "skipped-many"
+            messaging_history = await get_assessment_end_messaging_history(
+                user_id=user_id, assessment_type=flow_id
+            )
+            flow_content = tasks.assessment_end_flow_map[flow_id.value]
+            task = ""
+            if not messaging_history:
+                previous_message_nr = 0
+                # previous_message_data: AssessmentEndItem = None
+                previous_message_valid_responses: list[str] | None = []
+            else:
+                previous_message_nr = messaging_history[-1].message_number
+                previous_message_data = [
+                    item
+                    for item in flow_content
+                    if item.message_nr == previous_message_nr
+                ][-1]
+            # If previous message number was 1, then content is based on score category
+            if previous_message_nr == 0:
+                pass
+            elif previous_message_nr == 1:
+                if isinstance(previous_message_data, AssessmentEndScoreBasedMessage):
+                    if score_category == "high":
+                        previous_message = (
+                            previous_message_data.high_score_content.content
+                        )
+                        previous_message_valid_responses = (
+                            previous_message_data.high_score_content.valid_responses
+                        )
+                    elif score_category == "medium":
+                        previous_message = (
+                            previous_message_data.medium_score_content.content
+                        )
+                        previous_message_valid_responses = (
+                            previous_message_data.medium_score_content.valid_responses
+                        )
+                    elif score_category == "low":
+                        previous_message = (
+                            previous_message_data.low_score_content.content
+                        )
+                        previous_message_valid_responses = (
+                            previous_message_data.low_score_content.valid_responses
+                        )
+                    else:
+                        previous_message = (
+                            previous_message_data.skipped_many_content.content
+                        )
+                        previous_message_valid_responses = (
+                            previous_message_data.skipped_many_content.valid_responses
+                        )
+                else:
+                    logger.error("Wrong content type.")
+                    break
+            # For previous message numbers 2/3, content is the same across score categories.
+            else:
+                if isinstance(previous_message_data, AssessmentEndSimpleMessage):
+                    previous_message = previous_message_data.content
+                    previous_message_valid_responses = (
+                        previous_message_data.valid_responses
+                    )
+                else:
+                    logger.error("Wrong content type.")
+                    break
+            if not previous_message_valid_responses and previous_message_nr != 0:
+                logger.error("Valid responses not found.")
+                break
+            if previous_message_nr > 0:
+                intent, intent_related_response = tasks.handle_user_message(
+                    previous_message, user_response
+                )
+            else:
+                intent, intent_related_response = "JOURNEY_RESPONSE", ""
+            next_message_nr = previous_message_nr + 1
+
+            # If the user responded to the previous question, we process their response and determine what needs to happen next
+            if intent == "JOURNEY_RESPONSE" and user_response:
+                # If the user responded to a question that demands a response
+                if (
+                    (
+                        flow_id.value == "dma-pre-assessment"
+                        and next_message_nr in [2, 3]
+                    )
+                    or (
+                        flow_id.value == "behaviour-pre-assessment"
+                        and next_message_nr == 2
+                    )
+                    or (
+                        flow_id.value == "knowledge-pre-assessment"
+                        and next_message_nr == 2
+                    )
+                    or (
+                        flow_id.value == "attitude-pre-assessment"
+                        and next_message_nr == 2
+                    )
+                ):
+                    if not previous_message_valid_responses:
+                        logger.error("Valid responses not found.")
+                        break
+                    result = tasks.validate_assessment_end_response(
+                        previous_message=previous_message,
+                        previous_message_nr=next_message_nr - 1,
+                        previous_message_valid_responses=previous_message_valid_responses,
+                        user_response=user_response,
+                    )
+                    if result["next_message_number"] == next_message_nr - 1:
+                        # validation failed, send previous message again
+                        next_message_data = previous_message_data
+                    else:
+                        processed_user_response = result["processed_user_response"]
+                        # If the user response was valid, save it to the existing AssessmentEndMessagingHistory record
+                        await save_assessment_end_message(
+                            user_response,
+                            flow_id,
+                            next_message_nr - 1,
+                            processed_user_response,
+                        )
+                        # validation succeeded, so determine next message to send
+                        if next_message_nr > len(flow_content):
+                            # end of journey reached
+                            break
+                        next_message_data = [
+                            item
+                            for item in flow_content
+                            if item.message_nr == next_message_nr
+                        ][-1]
+
+                        # Now determine the task that's associated with the response
+                        if flow_id.value == "dma-pre-assessment":
+                            if (
+                                previous_message_nr == 1
+                                and score_category == "skipped-many"
+                            ):
+                                if processed_user_response == "Yes":
+                                    task = "REMIND_ME_LATER"
+                            elif previous_message_nr == 2:
+                                task = "STORE_FEEDBACK"
+                        elif flow_id.value == "behaviour-pre-assessment":
+                            if (
+                                previous_message_nr == 1
+                                and processed_user_response == "Remind me tomorrow"
+                            ):
+                                task = "REMIND_ME_LATER"
+                        elif flow_id.value == "knowledge-pre-assessment":
+                            if (
+                                previous_message_nr == 1
+                                and processed_user_response == "Remind me tomorrow"
+                            ):
+                                task = "REMIND_ME_LATER"
+                        elif flow_id.value == "attitude-pre-assessment":
+                            if previous_message_nr == 1:
+                                if score_category == "skipped-many":
+                                    if processed_user_response == "Yes":
+                                        task = "REMIND_ME_LATER"
+                                else:
+                                    task = "STORE_FEEDBACK"
+                    if isinstance(next_message_data, AssessmentEndSimpleMessage):
+                        next_message = next_message_data.content
+                    else:
+                        logger.error("Wrong content type.")
+                        break
+                # Else the user responded to the last question, which doesn't require a response
+                else:
+                    # Here we return an empty message because the user responded by the journey ended
+                    next_message = ""
+
+            elif intent == "JOURNEY_RESPONSE":
+                # This triggers if the journey is initiating (i.e. the next message to be sent is the first)
+                next_message_data = [
+                    item for item in flow_content if item.message_nr == next_message_nr
+                ][-1]
+                if isinstance(next_message_data, AssessmentEndScoreBasedMessage):
+                    if score_category == "high":
+                        next_message = next_message_data.high_score_content.content
+                    elif score_category == "medium":
+                        next_message = next_message_data.medium_score_content.content
+                    elif score_category == "low":
+                        next_message = next_message_data.low_score_content.content
+                    else:
+                        next_message = next_message_data.skipped_many_content.content
+                else:
+                    logger.error("Wrong content type.")
+                    break
+            else:
+                # It doesn't seem like the user is responding to the journey, and neither is it their first question, so we ask them the previous question again.
+                next_message_data = [
+                    item
+                    for item in flow_content
+                    if isinstance(item, AssessmentEndSimpleMessage)
+                    and item.message_nr == previous_message_nr
+                ][-1]
+                next_message = next_message_data.content
+
+            # If a new question is being sent, save it in a new AssessmentEndMessagingHistory record
+            if next_message and next_message_nr == previous_message_nr + 1:
+                await save_assessment_end_message(user_id, flow_id, next_message_nr, "")
+            print(f"Task: {task}")
+            print(f"Question #: {next_message_nr}")
+            print(f"Question: {next_message}")
+            user_response = await _get_user_response(
+                gt_lookup={},
+                flow_id=flow_id.value,
+                contextualized_question=next_message,
+                turn_identifier_key="message_nr",
+                turn_identifier_value=next_message_nr,
+            )
+            if user_response is None:
+                break
+            print(f"User_response: {user_response}")
+        # End of assessment-end messaging
+
+        # Inspect the assessment questions and results that were stored as history before deleting them:
+        history = await tasks.get_assessment_history(user_id, flow_id)
+        if history:
+            logger.info(
+                "Stored the following pre-assessment questions during simulation:"
+            )
+            for q in history:
+                logger.info(f"Question {q.question_number}: {q.question}")
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                await session.execute(
+                    delete(AssessmentHistory).where(
+                        AssessmentHistory.user_id == user_id,
+                        AssessmentHistory.assessment_id == flow_id.value,
+                    )
+                )
+        # And also the overall assessment result, if there is one:
+        assessment_result = await get_assessment_result(user_id, flow_id)
+        if assessment_result:
+            print("Assessment Result:")
+            print(assessment_result)
             async with AsyncSessionLocal() as session:
                 async with session.begin():
                     await session.execute(
-                        delete(AssessmentHistory).where(
-                            AssessmentHistory.user_id == user_id,
-                            AssessmentHistory.assessment_id == flow_id.value,
+                        delete(AssessmentResultHistory).where(
+                            AssessmentResultHistory.user_id == user_id,
+                            AssessmentResultHistory.assessment_id == flow_id.value,
                         )
                     )
-                    await session.commit()
 
         run_results["turns"] = dma_turns
         simulation_results.append(run_results)
 
     # ** KAB Scenario **
-    ### MODIFIED: Check GT data to decide if KAB should be simulated ###
     kab_flow_ids = [
+        AssessmentType.behaviour_pre_assessment,
         AssessmentType.knowledge_pre_assessment,
         AssessmentType.attitude_pre_assessment,
-        AssessmentType.behaviour_pre_assessment,
     ]
     kab_flows_in_gt = [flow for flow in kab_flow_ids if flow.value in gt_lookup_by_flow]
     sim_kab = bool(kab_flows_in_gt)
@@ -481,6 +734,16 @@ async def run_simulation(gt_scenarios: list[dict[str, Any]] | None = None):
 
     if sim_kab:
         flows_to_run = kab_flows_in_gt if gt_scenarios else kab_flow_ids
+
+        for flow_id in flows_to_run:
+            async with AsyncSessionLocal() as session:
+                async with session.begin():
+                    await session.execute(
+                        delete(AssessmentHistory).where(
+                            AssessmentHistory.user_id == user_id,
+                            AssessmentHistory.assessment_id == flow_id.value,
+                        )
+                    )
 
         for flow_id in flows_to_run:
             logger.info("\n--- Simulating KAB ---")
@@ -520,11 +783,13 @@ async def run_simulation(gt_scenarios: list[dict[str, Any]] | None = None):
                     user_id=user_id,
                     assessment_type=flow_id,
                     question_number=question_number,
+                    user_response=None,
                     question=contextualized_question,
+                    score=None,
                 )
 
                 # Simulate User Response
-                # Get user_response from GT data or input() #
+                # Get user_response from GT data or input()
                 print(f"Question #: {question_number}")
                 print(f"Question: {contextualized_question}")
                 user_response = ""
@@ -537,7 +802,7 @@ async def run_simulation(gt_scenarios: list[dict[str, Any]] | None = None):
                 )
                 if user_response is None:
                     break
-                print(f"Use_response: {user_response}")
+                print(f"User_response: {user_response}")
 
                 # Classify user's intent and act accordingly
                 intent, intent_related_response = tasks.handle_user_message(
@@ -609,27 +874,296 @@ async def run_simulation(gt_scenarios: list[dict[str, Any]] | None = None):
                     }
                 )
                 question_number = result["next_question_number"]
+                assessment_questions = tasks.load_and_validate_assessment_questions(
+                    tasks.assessment_map_to_their_pre[flow_id.value]
+                )
+                if assessment_questions:
+                    question_lookup = {
+                        q.question_number: q for q in assessment_questions
+                    }
+                    score_result = tasks._score_single_turn(
+                        Turn.model_validate(kab_turns[-1]),
+                        question_lookup,
+                    )
+                    await save_assessment_question(
+                        user_id=user_id,
+                        assessment_type=flow_id,
+                        question=None,
+                        question_number=kab_turns[-1]["question_number"],
+                        user_response=processed_user_response,
+                        score=score_result["score"],
+                    )
+
+            await calculate_and_store_assessment_result(user_id, flow_id)
+
+            # Start of assessment-end messaging
+            next_message = "placeholder"
+            user_response = ""
+            async with AsyncSessionLocal() as session:
+                async with session.begin():
+                    await session.execute(
+                        delete(AssessmentEndMessagingHistory).where(
+                            AssessmentEndMessagingHistory.user_id == user_id,
+                            AssessmentEndMessagingHistory.assessment_id
+                            == flow_id.value,
+                        )
+                    )
+            while next_message:
+                assessment_result = await get_assessment_result(user_id, flow_id)
+                if not assessment_result:
+                    logger.error(
+                        f"Overall assessment result for {flow_id.value} not found!"
+                    )
+                    break
+                score_category = assessment_result.category
+                if assessment_result.crossed_skip_threshold:
+                    score_category = "skipped-many"
+                messaging_history = await get_assessment_end_messaging_history(
+                    user_id=user_id, assessment_type=flow_id
+                )
+                flow_content = tasks.assessment_end_flow_map[flow_id.value]
+                task = ""
+                if not messaging_history:
+                    previous_message_nr = 0
+                    # previous_message_data = []
+                    previous_message_valid_responses = []
+                else:
+                    previous_message_nr = messaging_history[-1].message_number
+                    previous_message_data = [
+                        item
+                        for item in flow_content
+                        if item.message_nr == previous_message_nr
+                    ][-1]
+                # If previous message number was 1, then content is based on score category
+                if previous_message_nr == 0:
+                    pass
+                elif previous_message_nr == 1:
+                    if isinstance(
+                        previous_message_data, AssessmentEndScoreBasedMessage
+                    ):
+                        if score_category == "high":
+                            previous_message = (
+                                previous_message_data.high_score_content.content
+                            )
+                            previous_message_valid_responses = (
+                                previous_message_data.high_score_content.valid_responses
+                            )
+                        elif score_category == "medium":
+                            previous_message = (
+                                previous_message_data.medium_score_content.content
+                            )
+                            previous_message_valid_responses = previous_message_data.medium_score_content.valid_responses
+                        elif score_category == "low":
+                            previous_message = (
+                                previous_message_data.low_score_content.content
+                            )
+                            previous_message_valid_responses = (
+                                previous_message_data.low_score_content.valid_responses
+                            )
+                        else:
+                            previous_message = (
+                                previous_message_data.skipped_many_content.content
+                            )
+                            previous_message_valid_responses = previous_message_data.skipped_many_content.valid_responses
+                    else:
+                        logger.error("Wrong content type.")
+                        break
+                # For previous message numbers 2/3, content is the same across score categories.
+                else:
+                    if isinstance(previous_message_data, AssessmentEndSimpleMessage):
+                        previous_message = previous_message_data.content
+                        previous_message_valid_responses = (
+                            previous_message_data.valid_responses
+                        )
+                    else:
+                        logger.error("Wrong content type.")
+                        break
+
+                if not previous_message_valid_responses and previous_message_nr != 0:
+                    logger.error("Valid responses not found.")
+                    break
+                if previous_message_nr > 0:
+                    intent, intent_related_response = tasks.handle_user_message(
+                        previous_message, user_response
+                    )
+                else:
+                    intent, intent_related_response = "JOURNEY_RESPONSE", ""
+                next_message_nr = previous_message_nr + 1
+
+                # If the user responded to the previous question, we process their response and determine what needs to happen next
+                if intent == "JOURNEY_RESPONSE" and user_response:
+                    # If the user responded to a question that demands a response
+                    if (
+                        (
+                            flow_id.value == "dma-pre-assessment"
+                            and next_message_nr in [2, 3]
+                        )
+                        or (
+                            flow_id.value == "behaviour-pre-assessment"
+                            and next_message_nr == 2
+                        )
+                        or (
+                            flow_id.value == "knowledge-pre-assessment"
+                            and next_message_nr == 2
+                        )
+                        or (
+                            flow_id.value == "attitude-pre-assessment"
+                            and next_message_nr == 2
+                        )
+                    ):
+                        assert previous_message_valid_responses is not None, (
+                            "Valid responses not found!"
+                        )
+                        result = tasks.validate_assessment_end_response(
+                            previous_message=previous_message,
+                            previous_message_nr=next_message_nr - 1,
+                            previous_message_valid_responses=previous_message_valid_responses,
+                            user_response=user_response,
+                        )
+                        if result["next_message_number"] == next_message_nr - 1:
+                            # validation failed, send previous message again
+                            next_message_data = previous_message_data
+                        else:
+                            processed_user_response = result["processed_user_response"]
+                            # If the user response was valid, save it to the existing AssessmentEndMessagingHistory record
+                            await save_assessment_end_message(
+                                user_response,
+                                flow_id,
+                                next_message_nr - 1,
+                                processed_user_response,
+                            )
+                            # validation succeeded, so determine next message to send
+                            if next_message_nr > len(flow_content):
+                                # end of journey reached
+                                break
+                            next_message_data = [
+                                item
+                                for item in flow_content
+                                if item.message_nr == next_message_nr
+                            ][-1]
+
+                            # Now determine the task that's associated with the response
+                            if flow_id.value == "dma-pre-assessment":
+                                if (
+                                    previous_message_nr == 1
+                                    and score_category == "skipped-many"
+                                ):
+                                    if processed_user_response == "Yes":
+                                        task = "REMIND_ME_LATER"
+                                elif previous_message_nr == 2:
+                                    task = "STORE_FEEDBACK"
+                            elif flow_id.value == "behaviour-pre-assessment":
+                                if (
+                                    previous_message_nr == 1
+                                    and processed_user_response == "Remind me tomorrow"
+                                ):
+                                    task = "REMIND_ME_LATER"
+                            elif flow_id.value == "knowledge-pre-assessment":
+                                if (
+                                    previous_message_nr == 1
+                                    and processed_user_response == "Remind me tomorrow"
+                                ):
+                                    task = "REMIND_ME_LATER"
+                            elif flow_id.value == "attitude-pre-assessment":
+                                if previous_message_nr == 1:
+                                    if score_category == "skipped-many":
+                                        if processed_user_response == "Yes":
+                                            task = "REMIND_ME_LATER"
+                                    else:
+                                        task = "STORE_FEEDBACK"
+                        if isinstance(next_message_data, AssessmentEndSimpleMessage):
+                            next_message = next_message_data.content
+                        else:
+                            logger.error("Wrong content type.")
+                            break
+                    # Else the user responded to the last question, which doesn't require a response
+                    else:
+                        # Here we return an empty message because the user responded by the journey ended
+                        next_message = ""
+
+                elif intent == "JOURNEY_RESPONSE":
+                    # This triggers if the journey is initiating (i.e. the next message to be sent is the first)
+                    next_message_data = [
+                        item
+                        for item in flow_content
+                        if item.message_nr == next_message_nr
+                    ][-1]
+                    if isinstance(next_message_data, AssessmentEndScoreBasedMessage):
+                        if score_category == "high":
+                            next_message = next_message_data.high_score_content.content
+                        elif score_category == "medium":
+                            next_message = (
+                                next_message_data.medium_score_content.content
+                            )
+                        elif score_category == "low":
+                            next_message = next_message_data.low_score_content.content
+                        else:
+                            next_message = (
+                                next_message_data.skipped_many_content.content
+                            )
+                    else:
+                        logger.error("Wrong content type")
+                        break
+                else:
+                    # It doesn't seem like the user is responding to the journey, and neither is it their first question, so we ask them the previous question again.
+                    next_message_data = [
+                        item
+                        for item in flow_content
+                        if isinstance(item, AssessmentEndSimpleMessage)
+                        and item.message_nr == previous_message_nr
+                    ][-1]
+                    next_message = next_message_data.content
+
+                # If a new question is being sent, save it in a new AssessmentEndMessagingHistory record
+                if next_message and next_message_nr == previous_message_nr + 1:
+                    await save_assessment_end_message(
+                        user_id, flow_id, next_message_nr, ""
+                    )
+                print(f"Task: {task}")
+                print(f"Question #: {next_message_nr}")
+                print(f"Question: {next_message}")
+                user_response = await _get_user_response(
+                    gt_lookup={},
+                    flow_id=flow_id.value,
+                    contextualized_question=next_message,
+                    turn_identifier_key="message_nr",
+                    turn_identifier_value=next_message_nr,
+                )
+                if user_response is None:
+                    break
+                print(f"User_response: {user_response}")
+            # End of assessment-end messaging
 
             # Inspect the pre-assessment questions that were stored as history,
             # before deleting them:
-            if "-pre" in flow_id.value:
-                history = await get_pre_assessment_history(user_id, flow_id)
-                if history:
-                    logger.info(
-                        "Stored the following pre-assessment questions during simulation:"
+            history = await tasks.get_assessment_history(user_id, flow_id)
+            if history:
+                logger.info(
+                    "Stored the following assessment questions during simulation:"
+                )
+                for q in history:
+                    logger.info(f"Question {q.question_number}: {q.question}")
+            async with AsyncSessionLocal() as session:
+                async with session.begin():
+                    await session.execute(
+                        delete(AssessmentHistory).where(
+                            AssessmentHistory.user_id == user_id,
+                            AssessmentHistory.assessment_id == flow_id.value,
+                        )
                     )
-                    for q in history:
-                        logger.info(f"Question {q.question_number}: {q.question}")
+            # And also the overall assessment result, if there is one:
+            assessment_result = await get_assessment_result(user_id, flow_id)
+            if assessment_result:
+                print("Assessment Result:")
+                print(assessment_result)
                 async with AsyncSessionLocal() as session:
                     async with session.begin():
                         await session.execute(
-                            delete(AssessmentHistory).where(
-                                AssessmentHistory.user_id == user_id,
-                                AssessmentHistory.assessment_id
-                                == flow_id.value,
+                            delete(AssessmentResultHistory).where(
+                                AssessmentResultHistory.user_id == user_id,
+                                AssessmentResultHistory.assessment_id == flow_id.value,
                             )
                         )
-                        await session.commit()
 
             run_results["turns"] = kab_turns
             simulation_results.append(run_results)
@@ -709,7 +1243,7 @@ async def run_simulation(gt_scenarios: list[dict[str, Any]] | None = None):
                 turn_identifier_key="question_name",
                 turn_identifier_value=question_identifier,
             )
-            print(f"Use_response: {user_response}")
+            print(f"User_response: {user_response}")
             if user_response is None:
                 break
             ### END MODIFIED ###

--- a/src/ai4gd_momconnect_haystack/pipelines.py
+++ b/src/ai4gd_momconnect_haystack/pipelines.py
@@ -885,7 +885,7 @@ def create_intent_detection_pipeline() -> Pipeline | None:
     "{{ user_response }}"
 
     Please classify the user's message into one of these intents:
-    - 'JOURNEY_RESPONSE': The user is directly answering or attempting to answer the question asked.
+    - 'JOURNEY_RESPONSE': The user is directly answering, or attempting to answer, or skipping the question asked.
     - 'QUESTION_ABOUT_STUDY': The user is asking a question about the research study itself (e.g., "who are you?", "why are you asking this?").
     - 'HEALTH_QUESTION': The user is asking a new question related to health, pregnancy, or their wellbeing, instead of answering the question.
     - 'ASKING_TO_STOP_MESSAGES': The user expresses a desire to stop receiving messages.
@@ -1211,7 +1211,10 @@ def run_assessment_response_validator_pipeline(
 
 
 def run_assessment_end_response_validator_pipeline(
-    pipeline: Pipeline, user_response: str, valid_responses: list[str], previous_message: str
+    pipeline: Pipeline,
+    user_response: str,
+    valid_responses: list[str],
+    previous_message: str,
 ) -> str | None:
     """
     Run the assessment end response validator pipeline to validate a user's response.
@@ -1291,7 +1294,7 @@ def run_anc_survey_contextualization_pipeline(
     chat_history: list[str],
     original_question: str,
     valid_responses: list[str],
-) -> str | None:
+) -> str:
     """
     Runs the ANC survey contextualization pipeline.
     """

--- a/src/ai4gd_momconnect_haystack/pydantic_models.py
+++ b/src/ai4gd_momconnect_haystack/pydantic_models.py
@@ -1,16 +1,25 @@
 # models.py
 
-from typing import Any
+from typing import Any, TypeVar
 from pydantic import BaseModel, Field, model_validator
 
 
-# NEW: A model to represent a single response and its score
+# A generic model type
+T = TypeVar("T", bound=BaseModel)
+
+
 class ResponseScore(BaseModel):
     response: str
     score: int
 
 
-class Question(BaseModel):
+class AssessmentResult(BaseModel):
+    score: float
+    category: str
+    crossed_skip_threshold: bool
+
+
+class AssessmentQuestion(BaseModel):
     """
     Defines a flexible structure for any question from the doc store.
     It can handle scorable (assessment) and non-scorable (onboarding) questions.
@@ -19,14 +28,21 @@ class Question(BaseModel):
     question_number: int
     question_name: str | None = None
     content: str | None = None
-    pre_content: str | None = Field(None, alias="pre-content")
-    post_content: str | None = Field(None, alias="post-content")
-
-    # UPDATED: Replaced the old `valid_responses` with the new structure
-    valid_responses_and_scores: list[ResponseScore] | list[str] | None = Field(
+    valid_responses_and_scores: list[ResponseScore] | None = Field(
         None, alias="valid_responses_and_scores"
     )
+    content_type: str | None = None
 
+
+class OnboardingQuestion(BaseModel):
+    """
+    Defines a flexible structure for any question from the doc store.
+    It can handle scorable (assessment) and non-scorable (onboarding) questions.
+    """
+
+    question_number: int
+    content: str | None = None
+    valid_responses: list[str] | None = Field(None, alias="valid_responses")
     content_type: str | None = None
     collects: str | None = None
     reason: str | None = None
@@ -62,3 +78,43 @@ class AssessmentRun(BaseModel):
     scenario_id: str
     flow_type: str
     turns: list[Turn]
+
+
+class FAQ(BaseModel):
+    title: str
+    content: str
+
+
+class ANCSurveyQuestion(BaseModel):
+    title: str
+    content: str
+    content_type: str
+    valid_responses: list[str] | None = Field(None, alias="valid_responses")
+
+
+class AssessmentEndContentItem(BaseModel):
+    content: str
+    valid_responses: list[str] | None = Field(None, alias="valid_responses")
+
+
+class AssessmentEndScoreBasedMessage(BaseModel):
+    message_nr: int
+    high_score_content: AssessmentEndContentItem = Field(
+        ..., alias="high-score-content"
+    )
+    medium_score_content: AssessmentEndContentItem = Field(
+        ..., alias="medium-score-content"
+    )
+    low_score_content: AssessmentEndContentItem = Field(..., alias="low-score-content")
+    skipped_many_content: AssessmentEndContentItem = Field(
+        ..., alias="skipped-many-content"
+    )
+
+
+class AssessmentEndSimpleMessage(BaseModel):
+    message_nr: int
+    content: str
+    valid_responses: list[str] | None = Field(None, alias="valid_responses")
+
+
+AssessmentEndItem = AssessmentEndScoreBasedMessage | AssessmentEndSimpleMessage

--- a/src/ai4gd_momconnect_haystack/sqlalchemy_models.py
+++ b/src/ai4gd_momconnect_haystack/sqlalchemy_models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import Integer, String, JSON, DateTime
+from sqlalchemy import Boolean, Float, Integer, String, JSON, DateTime
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
 
@@ -47,9 +47,7 @@ class AssessmentHistory(Base):
     )
 
     def __repr__(self):
-        return (
-            f"<AssessmentHistory(user_id='{self.user_id}', updated_at='{self.updated_at}')>"
-        )
+        return f"<AssessmentHistory(user_id='{self.user_id}', updated_at='{self.updated_at}')>, question_number='{self.question_number}', score='{self.score}'"
 
 
 class AssessmentResultHistory(Base):
@@ -58,6 +56,8 @@ class AssessmentResultHistory(Base):
     user_id: Mapped[str] = mapped_column(String, primary_key=True, index=True)
     assessment_id: Mapped[str] = mapped_column(String, primary_key=True, index=True)
     category: Mapped[str] = mapped_column(String, nullable=False)
+    score: Mapped[float] = mapped_column(Float, nullable=False)
+    crossed_skip_threshold: Mapped[bool] = mapped_column(Boolean, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )
@@ -66,9 +66,7 @@ class AssessmentResultHistory(Base):
     )
 
     def __repr__(self):
-        return (
-            f"<AssessmentResultHistory(user_id='{self.user_id}', updated_at='{self.updated_at}')>"
-        )
+        return f"<AssessmentResultHistory(user_id='{self.user_id}', updated_at='{self.updated_at}', category='{self.category}', crossed_skip_threshold='{self.crossed_skip_threshold}')>"
 
 
 class AssessmentEndMessagingHistory(Base):
@@ -78,8 +76,12 @@ class AssessmentEndMessagingHistory(Base):
     assessment_id: Mapped[str] = mapped_column(String, primary_key=True, index=True)
     message_number: Mapped[int] = mapped_column(primary_key=True, index=True)
     user_response: Mapped[str] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), onupdate=func.now(), nullable=True
+    )
 
     def __repr__(self):
-        return (
-            f"<AssessmentEndMessagingHistory(user_id='{self.user_id}', updated_at='{self.updated_at}')>"
-        )
+        return f"<AssessmentEndMessagingHistory(user_id='{self.user_id}', updated_at='{self.updated_at}')>"

--- a/src/ai4gd_momconnect_haystack/sqlalchemy_models.py
+++ b/src/ai4gd_momconnect_haystack/sqlalchemy_models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import String, JSON, DateTime
+from sqlalchemy import Integer, String, JSON, DateTime
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
 
@@ -30,10 +30,56 @@ class ChatHistory(Base):
         )
 
 
-class PreAssessmentQuestionHistory(Base):
-    __tablename__ = "pre_assessment_question_history"
+class AssessmentHistory(Base):
+    __tablename__ = "assessment_history"
 
     user_id: Mapped[str] = mapped_column(String, primary_key=True, index=True)
     assessment_id: Mapped[str] = mapped_column(String, primary_key=True, index=True)
     question_number: Mapped[int] = mapped_column(primary_key=True, index=True)
     question: Mapped[str] = mapped_column(String, nullable=False)
+    user_response: Mapped[str] = mapped_column(String, nullable=True)
+    score: Mapped[int] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), onupdate=func.now(), nullable=True
+    )
+
+    def __repr__(self):
+        return (
+            f"<AssessmentHistory(user_id='{self.user_id}', updated_at='{self.updated_at}')>"
+        )
+
+
+class AssessmentResultHistory(Base):
+    __tablename__ = "assessment_result_history"
+
+    user_id: Mapped[str] = mapped_column(String, primary_key=True, index=True)
+    assessment_id: Mapped[str] = mapped_column(String, primary_key=True, index=True)
+    category: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), onupdate=func.now(), nullable=True
+    )
+
+    def __repr__(self):
+        return (
+            f"<AssessmentResultHistory(user_id='{self.user_id}', updated_at='{self.updated_at}')>"
+        )
+
+
+class AssessmentEndMessagingHistory(Base):
+    __tablename__ = "assessment_end_messaging_history"
+
+    user_id: Mapped[str] = mapped_column(String, primary_key=True, index=True)
+    assessment_id: Mapped[str] = mapped_column(String, primary_key=True, index=True)
+    message_number: Mapped[int] = mapped_column(primary_key=True, index=True)
+    user_response: Mapped[str] = mapped_column(String, nullable=True)
+
+    def __repr__(self):
+        return (
+            f"<AssessmentEndMessagingHistory(user_id='{self.user_id}', updated_at='{self.updated_at}')>"
+        )

--- a/src/ai4gd_momconnect_haystack/static_content/assessment_ends.json
+++ b/src/ai4gd_momconnect_haystack/static_content/assessment_ends.json
@@ -1,0 +1,123 @@
+{
+    "dma-pre-assessment": [
+        {
+            "message_nr": 1,
+            "high-score-content": {
+                "content": "Thank you for answering those!\n\nYou seem comfortable and confident making decisions about your health.\n\nKeep doing what you're doing 🤩\n\nType 'Next' to continue",
+                "valid_responses": ["Next"]
+            },
+            "medium-score-content": {
+                "content": "Thank you for answering those!\n\nYou seem comfortable and confident making decisions about your health.\n\nKeep doing what you're doing 🤩\n\nType 'Next' to continue",
+                "valid_responses": ["Next"]
+            },
+            "low-score-content": {
+                "content": "Thank you for answering those!\n\nYour answers show that you don't feel very confident making decisions about your health.\n\nDon't worry! MomConnect is here to help you be more confident ⭐\n\nType 'Next' to continue",
+                "valid_responses": ["Next"]
+            },
+            "skipped-many-content": {
+                "content": "You skipped more than half the questions, so we can't tell how you feel about healthcare 😞\n\nIt would be great if you could answer them when you feel ready.\n\nCan we remind you tomorrow? Respond with 'Yes' or 'No'.",
+                "valid_responses": ["Yes","No"]
+            }
+        },
+        {
+            "message_nr": 2,
+            "content": "You're finished! Thank you 🏆\n\n*Your life* 🗝️\n\n*Healthcare* ☀️\n\nHow easy was it to finish this?\n- Very easy\n- A little easy\n- OK\n- A little difficult\n- Very difficult",
+            "valid_responses": [
+                "Very easy",
+                "A little easy",
+                "OK",
+                "A little difficult",
+                "Very difficult"
+            ]
+        },
+        {
+            "message_nr": 3,
+            "content": "Thanks for your feedback 💕\n\nYou'll get a reminder for your next clinic check-up on MomConnect.\n\nHere, we'll be sending you some pregnancy health check questions soon. And we'll ask you about your check-up at the clinic 🏥\n\nEvery answer you give helps us make MomConnect better for everyone!\n\nClick on this link to go to MomConnect: https://wa.me/27796312456?text=menu"
+        }
+    ],
+    "behaviour-pre-assessment": [
+        {
+            "message_nr": 1,
+            "high-score-content": {
+                "content": "*Pregnancy Health Check*\n💜⚪⚪\n\nThank you for sharing! You're making healthy decisions for you and your unborn child 💪🏽\n\nRemember:\n\n• A healthy pregnancy needs healthy foods. Follow the health worker's advice 🥬🥚🥛🍎\n\n• And stay away from alcohol and cigarettes while you are pregnant or breastfeeding. It can harm your baby 🚬🍷\n\nAre you ready to move on to a few more questions? 👇🏽\n\nRespond with 'Yes' or 'Remind me tomorrow'",
+                "valid_responses": ["Yes","Remind me tomorrow"]
+            },
+            "medium-score-content": {
+                "content": "*Pregnancy Health Check*\n💜⚪⚪\n\nThank you for sharing.\n\nIt's important to have correct information so that you can make good decisions for you and your unborn child.\n\nYou know you can always get trustworthy information from MomConnect\n\nHere are some top tips about a healthy pregnancy:\n\n• A healthy pregnancy needs healthy foods. Follow the health worker's advice 🥬🥚🥛🍎\n\n• And stay away from alcohol and cigarettes while you are pregnant or breastfeeding. It can harm your baby 🚬🍷\n\nAre you ready to move on to a few more questions? 👇🏽\n\nRespond with 'Yes' or 'Remind me tomorrow'",
+                "valid_responses": ["Yes","Remind me tomorrow"]
+            },
+            "low-score-content": {
+                "content": "*Pregnancy Health Check*\n💜⚪⚪\n\nThank you for sharing.\n\nIt's important to have correct information so that you can make good decisions for you and your unborn child.\n\nYou know you can always get trustworthy information from MomConnect.\n\nHere are some top tips about a healthy pregnancy:\n\n• A healthy pregnancy needs healthy foods. Follow the health worker's advice 🥬🥚🥛🍎\n\n• And stay away from alcohol and cigarettes while you are pregnant or breastfeeding. It can harm your baby 🚬🍷\n\nAre you ready to move on to a few more questions? 👇🏽\n\nRespond with 'Yes' or 'Remind me tomorrow'",
+                "valid_responses": ["Yes","Remind me tomorrow"]
+            },
+            "skipped-many-content": {
+                "content": "We noticed you skipped some of the questions in this section. We can remind you about them tomorrow.\n\nThere are 8 more new questions to do in this health check. Do you want to do them now and finish it?\n\nRespond with 'Yes' or 'Remind me tomorrow'",
+                "valid_responses": ["Yes","Remind me tomorrow"]
+            }
+        }
+    ],
+    "knowledge-pre-assessment": [
+        {
+            "message_nr": 1,
+            "high-score-content": {
+                "content": "*Pregnancy Health Check*\n💜💙⚪\n\nThank you for taking the time to answer these! You know a lot about healthy pregnancy 🙌🏽\n\n*Here are the main points*\n• It's best to go to the clinic as soon as you know you're pregnant. This first pregnancy check-up should be before 14 weeks. You should have 8 or more check-ups in total 🏥\n\n• If your tummy stays tight, hard and is very painful you need to go to the clinic 🤰🏾\n\n• At your pregnancy check-ups, you should get the tetanus vaccine. This helps protect you and your baby after birth 💉\n\n• Iron and folic acid supplements are important for you and your unborn baby 💪🏽\n\nYou ready for the last 3 pregnancy questions? 👇🏽\n\nRespond with 'Yes' or 'Remind me tomorrow'",
+                "valid_responses": ["Yes","Remind me tomorrow"]
+            },
+            "medium-score-content": {
+                "content": "*Pregnancy Health Check*\n💜💙⚪\n\nThank you for taking the time to answer these! MomConnect can help you boost your knowledge about healthy pregnancy.\n\n• It's best to go to the clinic as soon as you know you're pregnant. This first pregnancy check-up should be before 14 weeks. You should have 8 or more check-ups in total 🏥\n\n• If your tummy stays tight, hard and is very painful you need to go to the clinic 🤰🏾\n\n• At your pregnancy check-ups, you should get the tetanus vaccine. This helps protect you and baby after birth 💉\n\n• Iron and folic acid supplements are important for you and your unborn baby 💪🏽\n\nYou ready for the last 3 pregnancy questions? 👇🏽\n\nRespond with 'Yes' or 'Remind me tomorrow'",
+                "valid_responses": ["Yes","Remind me tomorrow"]
+            },
+            "low-score-content": {
+                "content": "*Pregnancy Health Check*\n💜💙⚪\n\nThank you for taking the time to answer these! MomConnect can help you boost your knowledge about healthy pregnancy.\n\n• It's best to go to the clinic as soon as you know you're pregnant. This first pregnancy check-up should be before 14 weeks. You should have 8 or more check-ups in total 🏥\n\n• If your tummy stays tight, hard and is very painful you need to go to the clinic 🤰🏾\n\n• At your pregnancy check-ups, you should get the tetanus vaccine. This helps protect you and your baby after birth 💉\n\n• Iron and folic acid supplements are important for you and your unborn baby 💪🏽\n\nYou ready for the last 3 pregnancy questions? 👇🏽\n\nRespond with 'Yes' or 'Remind me tomorrow'",
+                "valid_responses": ["Yes","Remind me tomorrow"]
+            },
+            "skipped-many-content": {
+                "content": "We noticed you skipped some of the questions in this section. We can remind you about them tomorrow.\n\nThere are 3 new questions to do in this health check. Do you want to do them now and finish it?\n\nRespond with 'Yes' or 'Remind me tomorrow'",
+                "valid_responses": ["Yes","Remind me tomorrow"]
+            }
+        }
+    ],
+    "attitude-pre-assessment": [
+        {
+            "message_nr": 1,
+            "high-score-content": {
+                "content": "*Pregnancy Health Check*\n💜💙💛\n\nThank you for answering all these questions! You have completed all the questions and you know a lot about healthy pregnancy.\n\n*Remember*\n• Keep going to your pregnancy check-ups. This is important for you and baby 🏥\n\n• Try to plan to give birth at a clinic or hospital - it's generally safer. If not, have a skilled birth attendant to help you at the birth 💛\n\n• Get an HIV test when you have your pregnancy check-up. Early treatment can keep you healthy and protect baby 👶🏽\n\nThank you, you've completed the health check!\n\n*How easy was it to complete this?*\n- Very easy\n- A little easy\n- OK\n- A little difficult\n- Very difficult",
+                "valid_responses": [
+                    "Very easy",
+                    "A little easy",
+                    "OK",
+                    "A little difficult",
+                    "Very difficult"
+                ]
+            },
+            "medium-score-content": {
+                "content": "*Pregnancy Health Check*\n💜💙💛\n\nThank you for answering all these questions! When you have all the correct information, you can make the best decisions for you and baby.\n\n*Remember*\n• Keep going to to your pregnancy check-ups. This is important for you and baby 🏥\n\n• Try to plan to give birth in a clinic or hospital - it's generally safer. If not, have a skilled birth attendant to help you at the birth 💛\n\n• Get an HIV test at your pregnancy check-up. Early treatment can keep you healthy and protect the baby 👶🏽\n\nThank you, you've completed the health check!\n\n*How easy was it to complete this?*\n- Very easy\n- A little easy\n- OK\n- A little difficult\n- Very difficult",
+                "valid_responses": [
+                    "Very easy",
+                    "A little easy",
+                    "OK",
+                    "A little difficult",
+                    "Very difficult"
+                ]
+            },
+            "low-score-content": {
+                "content": "*Pregnancy Health Check*\n💜💙💛\n\nThank you for answering all these questions! When you have all the correct information, you can make the best decisions for you and baby.\n\n*Remember*\n• Keep going to to your pregnancy check-ups. This is important for you and your baby 🏥\n\n• Try to plan to give birth in a clinic or hospital - it's generally safer. If not, have a skilled birth attendant to help you at the birth 💛\n\n• Get an HIV test at your pregnancy check-up. Early treatment can keep you healthy and protect the baby 👶🏽\n\nThank you, you've completed the health check!\n\n*How easy was it to complete this?*\n- Very easy\n- A little easy\n- OK\n- A little difficult\n- Very difficult",
+                "valid_responses": [
+                    "Very easy",
+                    "A little easy",
+                    "OK",
+                    "A little difficult",
+                    "Very difficult"
+                ]
+            },
+            "skipped-many-content": {
+                "content": "We noticed you skipped some of your questions.\n\nCan we remind you to answer them again tomorrow? Respond with 'Yes' or 'No'.",
+                "valid_responses": ["Yes","No"]
+            }
+        },
+        {
+            "message_nr": 2,
+            "content": "Thanks for your feedback. We'll be back with some follow-up questions in the next few weeks! 💕\n\nClick on this link to go to MomConnect: https://wa.me/27796312456?text=menu"
+        }
+    ]
+}

--- a/src/ai4gd_momconnect_haystack/utilities.py
+++ b/src/ai4gd_momconnect_haystack/utilities.py
@@ -293,68 +293,6 @@ async def save_assessment_question(
             if score is not None:
                 historic_record.score = score
 
-            # # If all scores are available for the given assessment
-            # result = await session.execute(
-            #     select(AssessmentHistory)
-            #     .where(
-            #         AssessmentHistory.user_id == user_id,
-            #         AssessmentHistory.assessment_id == assessment_type.value,
-            #         AssessmentHistory.score.is_not(None),
-            #     )
-            #     .order_by(AssessmentHistory.question_number.asc())
-            # )
-            # historic_records = result.all()
-            # print(f"Number of historic records with scores: {len(historic_records)}")
-            # for rec in historic_records:
-            #     print(rec)
-            # if matches_assessment_question_length(
-            #     len(historic_records), assessment_type
-            # ):
-            #     # Calculate and store an AssessmentResultHistory.
-            #     turns = []
-            #     for rec in historic_records:
-            #         turns.append(
-            #             Turn.model_validate(
-            #                 {
-            #                     "question_number": rec.question_number,
-            #                     "user_response": rec.user_response,
-            #                 }
-            #             )
-            #         )
-            #     assessment_run = AssessmentRun.model_validate(
-            #         {
-            #             "scenario_id": user_id,
-            #             "flow_type": assessment_type.value,
-            #             "turns": turns,
-            #         }
-            #     )
-            #     assessment_result = score_assessment(assessment_run, assessment_type)
-            #     if assessment_result:
-            #         result_history = await session.execute(
-            #             select(AssessmentResultHistory).where(
-            #                 AssessmentResultHistory.user_id == user_id,
-            #                 AssessmentResultHistory.assessment_id
-            #                 == assessment_type.value,
-            #             )
-            #         )
-            #         historic_result_record = result_history.scalar_one_or_none()
-
-            #         if not historic_result_record:
-            #             historic_result_record = AssessmentResultHistory(
-            #                 user_id=user_id,
-            #                 assessment_id=assessment_type.value,
-            #                 category=assessment_result.category,
-            #                 score=assessment_result.score,
-            #                 crossed_skip_threshold=assessment_result.crossed_skip_threshold,
-            #             )
-            #             session.add(historic_result_record)
-            #         else:
-            #             historic_result_record.category = assessment_result.category
-            #             historic_result_record.score = assessment_result.score
-            #             historic_result_record.crossed_skip_threshold = (
-            #                 assessment_result.crossed_skip_threshold
-            #             )
-
 
 async def calculate_and_store_assessment_result(
     user_id: str, assessment_type: AssessmentType

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -260,11 +260,11 @@ async def test_onboarding():
 )
 @mock.patch("ai4gd_momconnect_haystack.api.validate_assessment_answer")
 @mock.patch(
-    "ai4gd_momconnect_haystack.api.save_pre_assessment_question",
+    "ai4gd_momconnect_haystack.api.save_assessment_question",
     new_callable=mock.AsyncMock,
 )
 async def test_assessment_chitchat(
-    save_pre_assessment_question,
+    save_assessment_question,
     validate_assessment_answer,
     get_assessment_question,
     handle_user_message,
@@ -304,7 +304,7 @@ async def test_assessment_chitchat(
     handle_user_message.assert_called_once_with("How are you feeling?", "Hello!")
     validate_assessment_answer.assert_not_called()
     get_assessment_question.assert_awaited_once()
-    save_pre_assessment_question.assert_awaited_once()
+    save_assessment_question.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -315,11 +315,11 @@ async def test_assessment_chitchat(
 )
 @mock.patch("ai4gd_momconnect_haystack.api.validate_assessment_answer")
 @mock.patch(
-    "ai4gd_momconnect_haystack.api.save_pre_assessment_question",
+    "ai4gd_momconnect_haystack.api.save_assessment_question",
     new_callable=mock.AsyncMock,
 )
 async def test_assessment_initial_message(
-    save_pre_assessment_question,
+    save_assessment_question,
     validate_assessment_answer,
     get_assessment_question,
     handle_user_message,
@@ -358,7 +358,7 @@ async def test_assessment_initial_message(
     handle_user_message.assert_not_called()
     validate_assessment_answer.assert_not_called()
     get_assessment_question.assert_awaited_once()
-    save_pre_assessment_question.assert_awaited_once()
+    save_assessment_question.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,6 +8,11 @@ from sentry_sdk import get_client as get_sentry_client
 
 from ai4gd_momconnect_haystack.api import app, setup_sentry
 from ai4gd_momconnect_haystack.enums import HistoryType
+from ai4gd_momconnect_haystack.pydantic_models import (
+    AssessmentEndScoreBasedMessage,
+    AssessmentResult,
+)
+from ai4gd_momconnect_haystack.sqlalchemy_models import AssessmentEndMessagingHistory
 
 
 def test_health():
@@ -471,6 +476,279 @@ async def test_assessment_valid_journey_response(
     save_assessment_question.assert_has_awaits(
         [call_to_save_answer, call_to_save_question], any_order=False
     )
+
+
+@pytest.mark.asyncio
+@mock.patch.dict(os.environ, {"API_TOKEN": "testtoken"}, clear=True)
+@mock.patch(
+    "ai4gd_momconnect_haystack.api.get_assessment_result", new_callable=mock.AsyncMock
+)
+@mock.patch(
+    "ai4gd_momconnect_haystack.api.get_assessment_end_messaging_history",
+    new_callable=mock.AsyncMock,
+)
+@mock.patch(
+    "ai4gd_momconnect_haystack.api.save_assessment_end_message",
+    new_callable=mock.AsyncMock,
+)
+@mock.patch("ai4gd_momconnect_haystack.api.get_content_from_message_data")
+@mock.patch(
+    "ai4gd_momconnect_haystack.api.assessment_end_flow_map",
+    {
+        "dma-pre-assessment": [
+            AssessmentEndScoreBasedMessage.model_validate(
+                {
+                    "message_nr": 1,
+                    "high-score-content": {"content": "High score content"},
+                    "medium-score-content": {"content": "Medium score content"},
+                    "low-score-content": {"content": "Low score content"},
+                    "skipped-many-content": {"content": "Skipped many content"},
+                }
+            )
+        ]
+    },
+)
+async def test_assessment_end_initial_message(
+    mock_get_content,
+    mock_save_message,
+    mock_get_history,
+    mock_get_result,
+):
+    """
+    Tests the initial call to the endpoint with no user_input.
+    It should return the first message of the assessment-end flow.
+    """
+    # --- Mock Setup ---
+    mock_get_result.return_value = AssessmentResult(
+        score=100.0, category="high", crossed_skip_threshold=False
+    )
+    mock_get_history.return_value = []
+    mock_get_content.return_value = ("High score content", None)
+
+    # --- API Call ---
+    client = TestClient(app)
+    response = client.post(
+        "/v1/assessment-end",
+        headers={"Authorization": "Token testtoken"},
+        json={
+            "user_id": "TestUser",
+            "user_input": "",
+            "flow_id": "dma-pre-assessment",
+        },
+    )
+
+    # --- Assertions ---
+    assert response.status_code == 200
+    assert response.json() == {
+        "message": "High score content",
+        "task": "",
+        "intent": "JOURNEY_RESPONSE",
+        "intent_related_response": "",
+    }
+
+    mock_get_result.assert_awaited_once()
+    mock_get_history.assert_awaited_once()
+    mock_save_message.assert_awaited_once_with("TestUser", "dma-pre-assessment", 1, "")
+
+
+@pytest.mark.asyncio
+@mock.patch.dict(os.environ, {"API_TOKEN": "testtoken"}, clear=True)
+@mock.patch(
+    "ai4gd_momconnect_haystack.api.get_assessment_result", new_callable=mock.AsyncMock
+)
+@mock.patch(
+    "ai4gd_momconnect_haystack.api.get_assessment_end_messaging_history",
+    new_callable=mock.AsyncMock,
+)
+@mock.patch(
+    "ai4gd_momconnect_haystack.api.save_assessment_end_message",
+    new_callable=mock.AsyncMock,
+)
+@mock.patch("ai4gd_momconnect_haystack.api.get_content_from_message_data")
+@mock.patch("ai4gd_momconnect_haystack.api.handle_user_message")
+@mock.patch("ai4gd_momconnect_haystack.api.validate_assessment_end_response")
+@mock.patch("ai4gd_momconnect_haystack.api.determine_task")
+@mock.patch("ai4gd_momconnect_haystack.api.assessment_end_flow_map")
+@mock.patch("ai4gd_momconnect_haystack.api.response_is_required_for")
+async def test_assessment_end_valid_response_to_required_question(
+    mock_response_required,
+    mock_flow_map,
+    mock_determine_task,
+    mock_validate_response,
+    mock_handle_user_message,
+    mock_get_content,
+    mock_save_message,
+    mock_get_history,
+    mock_get_result,
+):
+    """
+    Tests a valid user response to a message that requires validation.
+    The system should process the answer, save it, and return the next message.
+    """
+    # --- Mock Setup ---
+    mock_get_result.return_value = AssessmentResult(
+        score=100.0, category="high", crossed_skip_threshold=False
+    )
+    mock_get_history.return_value = [
+        AssessmentEndMessagingHistory(message_number=2, user_response="")
+    ]
+    mock_response_required.side_effect = lambda flow, nr: nr == 2
+
+    # Corrected keys to use aliases from the Pydantic model
+    flow_content = [
+        AssessmentEndScoreBasedMessage.model_validate(
+            {
+                "message_nr": 2,
+                "high-score-content": {
+                    "content": "Would you like a summary? (Yes/No)",
+                    "valid_responses": ["Yes", "No"],
+                },
+                "medium-score-content": {"content": "placeholder"},
+                "low-score-content": {"content": "placeholder"},
+                "skipped-many-content": {"content": "placeholder"},
+            }
+        ),
+        AssessmentEndScoreBasedMessage.model_validate(
+            {
+                "message_nr": 3,
+                "high-score-content": {"content": "Thank you for your feedback."},
+                "medium-score-content": {"content": "placeholder"},
+                "low-score-content": {"content": "placeholder"},
+                "skipped-many-content": {"content": "placeholder"},
+            }
+        ),
+    ]
+    mock_flow_map.__getitem__.return_value = flow_content
+
+    mock_get_content.side_effect = [
+        ("Would you like a summary? (Yes/No)", ["Yes", "No"]),
+        ("Thank you for your feedback.", None),
+    ]
+    mock_handle_user_message.return_value = ("JOURNEY_RESPONSE", "")
+    mock_validate_response.return_value = {
+        "processed_user_response": "Yes",
+        "next_message_number": 3,
+    }
+    mock_determine_task.return_value = "SEND_SUMMARY"
+
+    # --- API Call ---
+    client = TestClient(app)
+    response = client.post(
+        "/v1/assessment-end",
+        headers={"Authorization": "Token testtoken"},
+        json={
+            "user_id": "TestUser",
+            "user_input": "Yes please",
+            "flow_id": "dma-pre-assessment",
+        },
+    )
+
+    # --- Assertions ---
+    assert response.status_code == 200
+    assert response.json() == {
+        "message": "Thank you for your feedback.",
+        "task": "SEND_SUMMARY",
+        "intent": "JOURNEY_RESPONSE",
+        "intent_related_response": "",
+    }
+
+    mock_validate_response.assert_called_once()
+    mock_determine_task.assert_called_once()
+    assert mock_save_message.await_count == 2
+    call_to_save_answer = mock.call("TestUser", "dma-pre-assessment", 2, "Yes")
+    call_to_save_question = mock.call("TestUser", "dma-pre-assessment", 3, "")
+    mock_save_message.assert_has_awaits(
+        [call_to_save_answer, call_to_save_question], any_order=True
+    )
+
+
+@pytest.mark.asyncio
+@mock.patch.dict(os.environ, {"API_TOKEN": "testtoken"}, clear=True)
+@mock.patch(
+    "ai4gd_momconnect_haystack.api.get_assessment_result", new_callable=mock.AsyncMock
+)
+@mock.patch(
+    "ai4gd_momconnect_haystack.api.get_assessment_end_messaging_history",
+    new_callable=mock.AsyncMock,
+)
+@mock.patch(
+    "ai4gd_momconnect_haystack.api.save_assessment_end_message",
+    new_callable=mock.AsyncMock,
+)
+@mock.patch("ai4gd_momconnect_haystack.api.get_content_from_message_data")
+@mock.patch("ai4gd_momconnect_haystack.api.handle_user_message")
+@mock.patch("ai4gd_momconnect_haystack.api.validate_assessment_end_response")
+@mock.patch("ai4gd_momconnect_haystack.api.assessment_end_flow_map")
+@mock.patch("ai4gd_momconnect_haystack.api.response_is_required_for")
+async def test_assessment_end_invalid_response(
+    mock_response_required,
+    mock_flow_map,
+    mock_validate_response,
+    mock_handle_user_message,
+    mock_get_content,
+    mock_save_message,
+    mock_get_history,
+    mock_get_result,
+):
+    """
+    Tests an invalid user response to a required question.
+    The system should repeat the question.
+    """
+    # --- Mock Setup ---
+    mock_get_result.return_value = AssessmentResult(
+        score=100.0, category="high", crossed_skip_threshold=False
+    )
+    mock_get_history.return_value = [
+        AssessmentEndMessagingHistory(message_number=2, user_response="")
+    ]
+    mock_response_required.return_value = True
+
+    # Corrected keys to use aliases from the Pydantic model
+    flow_content = [
+        AssessmentEndScoreBasedMessage.model_validate(
+            {
+                "message_nr": 2,
+                "high-score-content": {
+                    "content": "Would you like a summary? (Yes/No)",
+                    "valid_responses": ["Yes", "No"],
+                },
+                "medium-score-content": {"content": "placeholder"},
+                "low-score-content": {"content": "placeholder"},
+                "skipped-many-content": {"content": "placeholder"},
+            }
+        )
+    ]
+    mock_flow_map.__getitem__.return_value = flow_content
+
+    mock_get_content.side_effect = [
+        ("Would you like a summary? (Yes/No)", ["Yes", "No"]),
+        ("Would you like a summary? (Yes/No)", ["Yes", "No"]),
+    ]
+    mock_handle_user_message.return_value = ("JOURNEY_RESPONSE", "")
+    mock_validate_response.return_value = {
+        "processed_user_response": None,
+        "next_message_number": 2,
+    }
+
+    # --- API Call ---
+    client = TestClient(app)
+    response = client.post(
+        "/v1/assessment-end",
+        headers={"Authorization": "Token testtoken"},
+        json={
+            "user_id": "TestUser",
+            "user_input": "Maybe, I'm not sure",
+            "flow_id": "dma-pre-assessment",
+        },
+    )
+
+    # --- Assertions ---
+    assert response.status_code == 200
+    assert response.json()["message"] == "Would you like a summary? (Yes/No)"
+    assert response.json()["task"] == ""
+
+    mock_validate_response.assert_called_once()
+    mock_save_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -4,7 +4,12 @@ from unittest import mock
 import pytest
 
 # Import the Pydantic models and the functions to be tested
-from ai4gd_momconnect_haystack.pydantic_models import AssessmentRun, Question, Turn
+from ai4gd_momconnect_haystack.enums import AssessmentType
+from ai4gd_momconnect_haystack.pydantic_models import (
+    AssessmentQuestion,
+    AssessmentRun,
+    Turn,
+)
 from ai4gd_momconnect_haystack.tasks import (
     _calculate_assessment_score_range,
     _score_single_turn,
@@ -14,7 +19,6 @@ from ai4gd_momconnect_haystack.tasks import (
     score_assessment_from_simulation,
     validate_assessment_answer,
 )
-from ai4gd_momconnect_haystack.utilities import AssessmentType
 
 # --- Test Data Fixtures ---
 
@@ -53,9 +57,11 @@ def raw_assessment_questions() -> list[dict[str, Any]]:
 
 
 @pytest.fixture
-def validated_assessment_questions(raw_assessment_questions) -> list[Question]:
+def validated_assessment_questions(
+    raw_assessment_questions,
+) -> list[AssessmentQuestion]:
     """Provides a list of validated Pydantic Question models."""
-    return [Question.model_validate(q) for q in raw_assessment_questions]
+    return [AssessmentQuestion.model_validate(q) for q in raw_assessment_questions]
 
 
 @pytest.fixture
@@ -192,7 +198,7 @@ async def test_get_assessment_question():
             return_value="mock_question",
         ) as mock_run_pipeline,
         mock.patch(
-            "ai4gd_momconnect_haystack.tasks.get_pre_assessment_history",
+            "ai4gd_momconnect_haystack.tasks.get_assessment_history",
             new_callable=mock.AsyncMock,
             return_value=[],
         ) as mock_get_history,
@@ -224,7 +230,7 @@ async def test_get_last_assessment_question():
             return_value="mock_question",
         ) as mock_run_pipeline,
         mock.patch(
-            "ai4gd_momconnect_haystack.tasks.get_pre_assessment_history",
+            "ai4gd_momconnect_haystack.tasks.get_assessment_history",
             new_callable=mock.AsyncMock,
             return_value=[],
         ) as mock_get_history,


### PR DESCRIPTION
- `README.md`
	- Added information about the new `/assessment-end` endpoint that handles end-of-pre-assessment messaging
- `api.py`
	- Added assessment scoring to the `/assessment` endpoint
	- Added the `/assessment-end` endpoint
	- Refactored the loading of content files from JSON to load the data into new Pydantic models
	- Developed custom ingestion functions for the different types of content and updated `setup_document_store()` to use these function accordingly
- `enums.py`
	- Created this new file to host our `Enum` classes to avoid circular imports that started appearing with the new code changes
- `main.py`
	- Cleaned up some old/unnecessary comments
	- Revamped the simulation to also perform the end-of-pre-assessment messaging journeys
	- Changed the order of the simulation's KAB assessments to the correct order: B -> K -> A
- `pipelines.py`
	- Added a new pipeline to perform validation on user responses in the end-of-pre-assessment messaging journeys
	- Made a slight modification to the intent detection pipeline in an attempt to make it better at understanding a "Skip" user response
- `pydantic_models.py`
	- Added a number of new Pydantic models to handle content pieces with more clarity
- `sqlalchemy_models.py`
	- Replaced the `PreAssessmentQuestionHistory` table with a new `AssessmentHistory` table that will not only store pre-assessment questions, but also post-assessment questions, user responses and scores.
- `static_content/assessment_ends.json`
	- A new file containing the content for end-of-pre-assessment messaging
- `tasks.py`
	- Added a number of function to assist in scoring of assessments and in handling the end-of-assessment messaging journey
- `utilities.py`
	- Added a number of function to assist in scoring of assessments and in handling the end-of-assessment messaging journey
- `test_api.py`
	- Added a new test for the `/assessment` endpoint
- `test_tasks.py`
	- Minor changes