### PR TITLE
Pipeline improvements wrt user friendliness

### DIFF
--- a/src/ai4gd_momconnect_haystack/assessment_logic.py
+++ b/src/ai4gd_momconnect_haystack/assessment_logic.py
@@ -25,6 +25,7 @@ from ai4gd_momconnect_haystack.utilities import (
     kab_b_post_flow_id,
     kab_k_post_flow_id,
     kab_k_pre_flow_id,
+    prepare_valid_responses_to_use_in_assessment_system_prompt,
 )
 
 
@@ -158,10 +159,23 @@ def validate_assessment_answer(
             "next_question_number": question_number,
         }
     valid_responses = [item.response for item in valid_responses_and_scores]
+    if "dma" in current_flow_id:
+        flow_id_to_use = "dma-assessment"
+    elif "knowledge" in current_flow_id:
+        flow_id_to_use = "knowledge-assessment"
+    elif "attitude" in current_flow_id:
+        flow_id_to_use = "attitude-assessment"
+    else:
+        flow_id_to_use = "behaviour-pre-assessment"
+    valid_responses_for_prompt = (
+        prepare_valid_responses_to_use_in_assessment_system_prompt(
+            flow_id_to_use, question_number, current_question
+        )
+    )
 
     validator_pipe = pipelines.create_assessment_response_validator_pipeline()
     processed_user_response = pipelines.run_assessment_response_validator_pipeline(
-        validator_pipe, user_response, valid_responses
+        validator_pipe, user_response, valid_responses, valid_responses_for_prompt
     )
 
     # Move to the next step, or try again if the response was invalid

--- a/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250630-1930.json
+++ b/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250630-1930.json
@@ -1,0 +1,57 @@
+[
+  {
+    "scenario_id": "onboarding_user_123_250616-0635",
+    "flow_type": "onboarding",
+    "turns": [
+      {
+        "question_name": "phone_ownership",
+        "question_number": null,
+        "llm_utterance": "Do you own the phone you're using right now? \ud83d\udcf1",
+        "user_utterance": "No, I don't own this phone.",
+        "user_response": "No"
+      },
+      {
+        "question_name": "hunger_days",
+        "question_number": null,
+        "llm_utterance": "How many days in the last week did you miss a meal because there wasn't money for food? \ud83c\udf5e",
+        "user_utterance": "I sometimes go without food, maybe 3-4 days.",
+        "user_response": "3-4 days"
+      },
+      {
+        "question_name": "num_children",
+        "question_number": null,
+        "llm_utterance": "How many children do you have? Including all your children of any age. \ud83d\udc76\ud83c\udffd",
+        "user_utterance": "I have one little one already.",
+        "user_response": "1"
+      },
+      {
+        "question_name": "area_type",
+        "question_number": null,
+        "llm_utterance": "What type of area do you currently reside in? \ud83c\udfd8\ufe0f\n\na. City\nb. Township or suburb\nc. Town\nd. Farm or smallholding\ne. Village\nf. Rural area",
+        "user_utterance": "I live on a farm.",
+        "user_response": "Farm or smallholding"
+      },
+      {
+        "question_name": "education_level",
+        "question_number": null,
+        "llm_utterance": "What is your highest level of education completed? \ud83d\udcda\n\na. No school\nb. Some primary\nc. Finished primary\nd. Some high school\ne. Finished high school\nf. More than high school\ng. Don't know",
+        "user_utterance": "I only finished Grade 9 at school.",
+        "user_response": "Finished high school"
+      },
+      {
+        "question_name": "relationship_status",
+        "question_number": null,
+        "llm_utterance": "What's your current relationship status? \ud83d\udc64\n\na. Single\nb. Relationship\nc. Married",
+        "user_utterance": "I am single.",
+        "user_response": "Single"
+      },
+      {
+        "question_name": "province",
+        "question_number": null,
+        "llm_utterance": "Which province do you live in on the farm? \ud83c\udf33\n\na. Eastern Cape\nb. Free State\nc. Gauteng\nd. KwaZulu-Natal\ne. Limpopo\nf. Mpumalanga\ng. Northern Cape\nh. North West\ni. Western Cape",
+        "user_utterance": "I live on a farm out in the North West.",
+        "user_response": "North West"
+      }
+    ]
+  }
+]

--- a/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250630-1930.report.txt
+++ b/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250630-1930.report.txt
@@ -1,0 +1,53 @@
+
+==================================================
+              DETAILED TURN-BY-TURN REPORT
+==================================================
+
+--- Turn: onboarding_user_123_250616-0635 (onboarding) | ID: province ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 0.10 ] Question Consistency
+       Reason: The score is 0.10 because the output primarily consists of multiple-choice options rather than a direct answer to the question about the province of residence. This lack of direct relevance significantly lowers the score, as the response does not address the input query effectively.
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: onboarding_user_123_250616-0635 (onboarding) | ID: area_type ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: onboarding_user_123_250616-0635 (onboarding) | ID: relationship_status ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: onboarding_user_123_250616-0635 (onboarding) | ID: education_level ---
+  [❌] Extraction Accuracy: FAILED
+       Details: Expected: 'some high school', Got: 'finished high school'
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: onboarding_user_123_250616-0635 (onboarding) | ID: hunger_days ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: onboarding_user_123_250616-0635 (onboarding) | ID: num_children ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: onboarding_user_123_250616-0635 (onboarding) | ID: phone_ownership ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+
+==================================================
+              PERFORMANCE SUMMARY REPORT
+==================================================
+
+📊 Onboarding Performance (7 turns evaluated):
+  - Extraction Accuracy: 85.71%
+  - Question Consistency Score (Avg): 0.87
+  - Response Appropriateness Score (Avg): 1.00
+
+==================================================

--- a/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250630-1933.json
+++ b/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250630-1933.json
@@ -1,0 +1,52 @@
+[
+  {
+    "scenario_id": "dma-assessment_user_123_250616-0635",
+    "flow_type": "dma-pre-assessment",
+    "overall_score": 20,
+    "score_percentage": 100.0,
+    "assessment_min_score": 0,
+    "assessment_max_score": 20,
+    "turns": [
+      {
+        "question_name": null,
+        "question_number": 1,
+        "llm_utterance": "To what extent do you feel capable of making decisions about your health?\n\n1. I strongly agree\n2. I agree\n3. I'm not sure\n4. I disagree\n5. I strongly disagree",
+        "user_utterance": "I strongly agree",
+        "user_response": "I strongly agree",
+        "score": 4
+      },
+      {
+        "question_name": null,
+        "question_number": 2,
+        "llm_utterance": "Do you feel comfortable talking about your health issues with a health worker?\n\n1. I strongly agree\n2. I agree\n3. I'm not sure\n4. I disagree\n5. I strongly disagree",
+        "user_utterance": "I strongly agree",
+        "user_response": "I strongly agree",
+        "score": 4
+      },
+      {
+        "question_name": null,
+        "question_number": 3,
+        "llm_utterance": "Do you feel that you can disagree with a health worker about your treatment plan?\n\n1. I strongly agree\n2. I agree\n3. I'm not sure\n4. I disagree\n5. I strongly disagree",
+        "user_utterance": "I strongly agree",
+        "user_response": "I strongly agree",
+        "score": 4
+      },
+      {
+        "question_name": null,
+        "question_number": 4,
+        "llm_utterance": "Almost done! Do you feel that you can do things to improve your health?\n\n1. I strongly agree\n2. I agree\n3. I'm not sure\n4. I disagree\n5. I strongly disagree",
+        "user_utterance": "I strongly agree",
+        "user_response": "I strongly agree",
+        "score": 4
+      },
+      {
+        "question_name": null,
+        "question_number": 5,
+        "llm_utterance": "Do you feel that you can find information about your health from other places, not just a health worker?\n\n1. I strongly agree\n2. I agree\n3. I'm not sure\n4. I disagree\n5. I strongly disagree",
+        "user_utterance": "I strongly agree",
+        "user_response": "I strongly agree",
+        "score": 4
+      }
+    ]
+  }
+]

--- a/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250630-1933.report.txt
+++ b/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250630-1933.report.txt
@@ -1,0 +1,41 @@
+
+==================================================
+              DETAILED TURN-BY-TURN REPORT
+==================================================
+
+--- Turn: dma-assessment_user_123_250616-0635 (dma-pre-assessment) | ID: 1 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: dma-assessment_user_123_250616-0635 (dma-pre-assessment) | ID: 2 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: dma-assessment_user_123_250616-0635 (dma-pre-assessment) | ID: 3 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: dma-assessment_user_123_250616-0635 (dma-pre-assessment) | ID: 4 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 0.86 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: dma-assessment_user_123_250616-0635 (dma-pre-assessment) | ID: 5 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+
+==================================================
+              PERFORMANCE SUMMARY REPORT
+==================================================
+
+📊 Dma-pre-assessment Performance (5 turns evaluated):
+  - Extraction Accuracy: 100.00%
+  - Question Consistency Score (Avg): 0.97
+  - Response Appropriateness Score (Avg): 1.00
+
+==================================================

--- a/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250630-1935.json
+++ b/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250630-1935.json
@@ -1,0 +1,104 @@
+[
+  {
+    "scenario_id": "behaviour-pre-assessment_user_123_250616-0635",
+    "flow_type": "behaviour-pre-assessment",
+    "overall_score": 6,
+    "score_percentage": 85.71,
+    "assessment_min_score": 0,
+    "assessment_max_score": 7,
+    "turns": [
+      {
+        "question_name": null,
+        "question_number": 1,
+        "llm_utterance": "How many times have you visited the clinic for a pregnancy check-up during this pregnancy so far?",
+        "user_utterance": "3",
+        "user_response": "3",
+        "score": 3
+      },
+      {
+        "question_name": null,
+        "question_number": 2,
+        "llm_utterance": "In this pregnancy, have you made any changes to your diet based on information from a healthcare worker?",
+        "user_utterance": "No",
+        "user_response": "No",
+        "score": 2
+      },
+      {
+        "question_name": null,
+        "question_number": 3,
+        "llm_utterance": "During your current pregnancy, how many doses of the tetanus vaccine (Tdap) have you received so far?\n\n0 or 1?",
+        "user_utterance": "1",
+        "user_response": "1",
+        "score": 1
+      },
+      {
+        "question_name": null,
+        "question_number": 4,
+        "llm_utterance": "Since becoming pregnant, have you consumed any alcohol or smoked? \ud83e\udec3\ud83c\udffd\n\nPlease reply with \"Yes\" or \"No\".",
+        "user_utterance": "Yes",
+        "user_response": "Yes",
+        "score": 0
+      }
+    ]
+  },
+  {
+    "scenario_id": "knowledge-pre-assessment_user_123_250616-0635",
+    "flow_type": "knowledge-pre-assessment",
+    "overall_score": 0,
+    "score_percentage": 0.0,
+    "assessment_min_score": 0,
+    "assessment_max_score": 6,
+    "turns": [
+      {
+        "question_name": null,
+        "question_number": 1,
+        "llm_utterance": "When do you think you should get your first pregnancy check-up during your pregnancy? \ud83e\udd30\ud83c\udffd\n\na. Before 14 weeks\nb. At about 16 weeks\nc. At about 20 weeks\nd. At about 24 weeks\ne. At birth\nf. I don't know",
+        "user_utterance": "Before 14 weeks",
+        "user_response": "Before 14 weeks",
+        "score": 0
+      },
+      {
+        "question_name": null,
+        "question_number": 2,
+        "llm_utterance": "During your pregnancy, which of these signs means you need to go to the hospital immediately? \ud83e\udd30\ud83c\udffd\n\na. You have contractions that stop when you move\nb. Your tummy stays tight, hard and is very painful\nc. Your lower back aches all day",
+        "user_utterance": "I don't know",
+        "user_response": "I don't know",
+        "score": 0
+      }
+    ]
+  },
+  {
+    "scenario_id": "attitude-pre-assessment_user_123_250616-0635",
+    "flow_type": "attitude-pre-assessment",
+    "overall_score": 13,
+    "score_percentage": 86.67,
+    "assessment_min_score": 0,
+    "assessment_max_score": 15,
+    "turns": [
+      {
+        "question_name": null,
+        "question_number": 1,
+        "llm_utterance": "Do you agree with this statement: Regular pregnancy check-ups are a good way to ensure the health of both you and your unborn baby?\n\n1. I strongly agree\n2. I agree\n3. I'm not sure\n4. I disagree\n5. I strongly disagree",
+        "user_utterance": "I strongly agree",
+        "user_response": "I strongly agree",
+        "score": 5
+      },
+      {
+        "question_name": null,
+        "question_number": 2,
+        "llm_utterance": "Is home birth safer than giving birth in a hospital?\n\n1. I strongly agree\n2. I agree\n3. I'm not sure\n4. I disagree\n5. I strongly disagree",
+        "user_utterance": "I disagree",
+        "user_response": "I disagree",
+        "score": 4
+      },
+      {
+        "question_name": null,
+        "question_number": 3,
+        "llm_utterance": "Is it important for a 33-year-old pregnant woman to get an HIV test when she is pregnant?\n\n1. I strongly agree\n2. I agree\n3. I'm not sure\n4. I disagree\n5. I strongly disagree",
+        "user_utterance": "I agree",
+        "user_response": "I agree",
+        "score": 4
+      }
+    ]
+  }
+]

--- a/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250630-1935.report.txt
+++ b/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250630-1935.report.txt
@@ -1,0 +1,71 @@
+
+==================================================
+              DETAILED TURN-BY-TURN REPORT
+==================================================
+
+--- Turn: behaviour-pre-assessment_user_123_250616-0635 (behaviour-pre-assessment) | ID: 1 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: behaviour-pre-assessment_user_123_250616-0635 (behaviour-pre-assessment) | ID: 2 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: behaviour-pre-assessment_user_123_250616-0635 (behaviour-pre-assessment) | ID: 3 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: behaviour-pre-assessment_user_123_250616-0635 (behaviour-pre-assessment) | ID: 4 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: knowledge-pre-assessment_user_123_250616-0635 (knowledge-pre-assessment) | ID: 1 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 0.83 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: knowledge-pre-assessment_user_123_250616-0635 (knowledge-pre-assessment) | ID: 2 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: attitude-pre-assessment_user_123_250616-0635 (attitude-pre-assessment) | ID: 1 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: attitude-pre-assessment_user_123_250616-0635 (attitude-pre-assessment) | ID: 2 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: attitude-pre-assessment_user_123_250616-0635 (attitude-pre-assessment) | ID: 3 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+
+==================================================
+              PERFORMANCE SUMMARY REPORT
+==================================================
+
+📊 Behaviour-pre-assessment Performance (4 turns evaluated):
+  - Extraction Accuracy: 100.00%
+  - Question Consistency Score (Avg): 1.00
+  - Response Appropriateness Score (Avg): 1.00
+
+📊 Knowledge-pre-assessment Performance (2 turns evaluated):
+  - Extraction Accuracy: 100.00%
+  - Question Consistency Score (Avg): 0.92
+  - Response Appropriateness Score (Avg): 1.00
+
+📊 Attitude-pre-assessment Performance (3 turns evaluated):
+  - Extraction Accuracy: 100.00%
+  - Question Consistency Score (Avg): 1.00
+  - Response Appropriateness Score (Avg): 1.00
+
+==================================================

--- a/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250630-1938.json
+++ b/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250630-1938.json
@@ -1,0 +1,71 @@
+[
+  {
+    "scenario_id": "anc-survey_user_123_250616-0635",
+    "flow_type": "anc-survey",
+    "turns": [
+      {
+        "question_name": "start",
+        "question_number": null,
+        "llm_utterance": "Hey there! Did you have your *prenatal check-up* scheduled for this week? \ud83c\udfe5\n\nPlease reply with one of the following:\n- 'Yes, I went'\n- 'No, I'm not going'\n- 'I'm going soon'",
+        "user_utterance": "Yes",
+        "user_response": "Yes, I went"
+      },
+      {
+        "question_name": "Q_seen",
+        "question_number": null,
+        "llm_utterance": "Did a health worker attend to you during your prenatal check-up?",
+        "user_utterance": "Ya",
+        "user_response": "Yes"
+      },
+      {
+        "question_name": "seen_yes",
+        "question_number": null,
+        "llm_utterance": "That's great to hear \ud83c\udf1f Would you be able to spare 2 minutes to share with us how your prenatal check-up went?\n\nPlease reply with one of the following:\n- 'Yes'\n- 'Remind me tomorrow'",
+        "user_utterance": "Ok",
+        "user_response": "Yes"
+      },
+      {
+        "question_name": "Q_bp",
+        "question_number": null,
+        "llm_utterance": "During your last check-up, did a health worker measure your blood pressure?",
+        "user_utterance": "I don't know",
+        "user_response": "I don't know"
+      },
+      {
+        "question_name": "Q_experience",
+        "question_number": null,
+        "llm_utterance": "How would you rate your overall experience at the check-up?\n\na. Very good\nb. Good\nc. OK\nd. Bad\ne. Very bad",
+        "user_utterance": "Cool",
+        "user_response": "OK"
+      },
+      {
+        "question_name": "good",
+        "question_number": null,
+        "llm_utterance": "Thank you for sharing. There are just 2 more questions to go. Your responses will help us improve services for pregnant women in South Africa. Would you like to continue?\n\nPlease reply with Continue to continue.",
+        "user_utterance": "Yes",
+        "user_response": "Continue"
+      },
+      {
+        "question_name": "Q_visit_bad",
+        "question_number": null,
+        "llm_utterance": "Please choose from the following options to share what made you feel the most uncomfortable or caused you the biggest problem during your check-up:\n\na. No maternity record \ud83d\udcdd\nb. Shamed/embarrassed \ud83d\ude33\nc. No privacy \ud83e\udd10\nd. Not enough info \u2139\ufe0f\ne. Staff disrespectful \ud83e\udd2c\nf. Asked to pay \ud83d\udcb0\ng. Waited a long time \u231b\nh. Something else \ud83d\ude1e",
+        "user_utterance": "had to wait long time",
+        "user_response": "Waited a long time \u231b"
+      },
+      {
+        "question_name": "Q_challenges",
+        "question_number": null,
+        "llm_utterance": "Sometimes it can be tough to get to these check-ups. If you face challenges, what is your *main difficulty*?\n\na. No challenges \ud83d\udc4c\nb. Transport \ud83d\ude8c\nc. No support \ud83e\udd1d\nd. Clinic opening hours \ud83c\udfe5\ne. Something else \ud83d\ude1e",
+        "user_utterance": "It's hard to get there during clinic opening hours \ud83c\udfe5",
+        "user_response": "Clinic opening hours \ud83c\udfe5"
+      },
+      {
+        "question_name": "intent",
+        "question_number": null,
+        "llm_utterance": "Looking ahead, do you plan to attend your next prenatal check-up to ensure the best health for you and your baby?",
+        "user_utterance": "Ja",
+        "user_response": "Yes, I will"
+      }
+    ]
+  }
+]

--- a/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250630-1938.report.txt
+++ b/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250630-1938.report.txt
@@ -1,0 +1,66 @@
+
+==================================================
+              DETAILED TURN-BY-TURN REPORT
+==================================================
+
+--- Turn: anc-survey_user_123_250616-0635 (anc-survey) | ID: start ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 0.67 ] Question Consistency
+       Reason: The score is 0.67 because while the response partially addresses the question about the pregnancy check-up, it includes irrelevant elements like a greeting and a prompt for response format, which detract from its directness and clarity.
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: anc-survey_user_123_250616-0635 (anc-survey) | ID: Q_seen ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: anc-survey_user_123_250616-0635 (anc-survey) | ID: seen_yes ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 0.40 ] Question Consistency
+       Reason: The score is 0.40 because the output contains multiple response format prompts and options that do not directly address the input's request for feedback, reducing its relevance.
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: anc-survey_user_123_250616-0635 (anc-survey) | ID: Q_bp ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: anc-survey_user_123_250616-0635 (anc-survey) | ID: Q_experience ---
+  [❌] Extraction Accuracy: FAILED
+       Details: Expected: 'good', Got: 'ok'
+  [ score: 0.17 ] Question Consistency
+       Reason: The score is 0.17 because the output primarily consisted of options for rating the experience rather than directly addressing the question about the overall experience at the check-up. This led to a lack of relevant content, which significantly lowered the score.
+  [ score: 0.00 ] Response Appropriateness
+       Reason: The score is 0.00 because the statement 'cool' is completely irrelevant to the question about rating an experience at a check-up. It does not address any of the provided options or offer any insight into the experience.
+
+--- Turn: anc-survey_user_123_250616-0635 (anc-survey) | ID: good ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 0.80 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: anc-survey_user_123_250616-0635 (anc-survey) | ID: Q_visit_bad ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: anc-survey_user_123_250616-0635 (anc-survey) | ID: Q_challenges ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: anc-survey_user_123_250616-0635 (anc-survey) | ID: intent ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+
+==================================================
+              PERFORMANCE SUMMARY REPORT
+==================================================
+
+📊 Anc-survey Performance (9 turns evaluated):
+  - Extraction Accuracy: 88.89%
+  - Question Consistency Score (Avg): 0.78
+  - Response Appropriateness Score (Avg): 0.89
+
+==================================================

--- a/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250701-0316.json
+++ b/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250701-0316.json
@@ -1,0 +1,57 @@
+[
+  {
+    "scenario_id": "onboarding_user_123_250616-0635",
+    "flow_type": "onboarding",
+    "turns": [
+      {
+        "question_name": "phone_ownership",
+        "question_number": null,
+        "llm_utterance": "Do you currently own the phone you're using to chat with me? \ud83d\udcf1",
+        "user_utterance": "No, I don't own this phone.",
+        "user_response": "No"
+      },
+      {
+        "question_name": "num_children",
+        "question_number": null,
+        "llm_utterance": "How many children do you have, including all ages? This helps me tailor the information to suit your family situation.",
+        "user_utterance": "I have one little one already.",
+        "user_response": "1"
+      },
+      {
+        "question_name": "hunger_days",
+        "question_number": null,
+        "llm_utterance": "In the past week, have you experienced days where you couldn't afford a meal for yourself or your child? \ud83c\udf5e",
+        "user_utterance": "I sometimes go without food, maybe 3-4 days.",
+        "user_response": "3-4 days"
+      },
+      {
+        "question_name": "area_type",
+        "question_number": null,
+        "llm_utterance": "What type of area do you currently live in? This will help me understand your living environment better. \ud83c\udfd8\ufe0f\n\na. City\nb. Township or suburb\nc. Town\nd. Farm or smallholding\ne. Village\nf. Rural area",
+        "user_utterance": "I live on a farm.",
+        "user_response": "Farm or smallholding"
+      },
+      {
+        "question_name": "relationship_status",
+        "question_number": null,
+        "llm_utterance": "What's your current relationship status? \ud83d\udc64\n\na. Single\nb. Relationship\nc. Married",
+        "user_utterance": "I am single.",
+        "user_response": "Single"
+      },
+      {
+        "question_name": "education_level",
+        "question_number": null,
+        "llm_utterance": "What's your highest level of education? \ud83d\udcda\n\na. No school\nb. Some primary\nc. Finished primary\nd. Some high school\ne. Finished high school\nf. More than high school\ng. Don't know",
+        "user_utterance": "I only finished Grade 9 at school.",
+        "user_response": "Finished high school"
+      },
+      {
+        "question_name": "province",
+        "question_number": null,
+        "llm_utterance": "Which province do you currently live in on the farm? \ud83c\udf3e\n\na. Eastern Cape\nb. Free State\nc. Gauteng\nd. KwaZulu-Natal\ne. Limpopo\nf. Mpumalanga\ng. Northern Cape\nh. North West\ni. Western Cape",
+        "user_utterance": "I live on a farm out in the North West.",
+        "user_response": "North West"
+      }
+    ]
+  }
+]

--- a/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250701-0316.report.txt
+++ b/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250701-0316.report.txt
@@ -1,0 +1,52 @@
+
+==================================================
+              DETAILED TURN-BY-TURN REPORT
+==================================================
+
+--- Turn: onboarding_user_123_250616-0635 (onboarding) | ID: province ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: onboarding_user_123_250616-0635 (onboarding) | ID: area_type ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: onboarding_user_123_250616-0635 (onboarding) | ID: relationship_status ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: onboarding_user_123_250616-0635 (onboarding) | ID: education_level ---
+  [❌] Extraction Accuracy: FAILED
+       Details: Expected: 'some high school', Got: 'finished high school'
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: onboarding_user_123_250616-0635 (onboarding) | ID: hunger_days ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: onboarding_user_123_250616-0635 (onboarding) | ID: num_children ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: onboarding_user_123_250616-0635 (onboarding) | ID: phone_ownership ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+
+==================================================
+              PERFORMANCE SUMMARY REPORT
+==================================================
+
+📊 Onboarding Performance (7 turns evaluated):
+  - Extraction Accuracy: 85.71%
+  - Question Consistency Score (Avg): 1.00
+  - Response Appropriateness Score (Avg): 1.00
+
+==================================================

--- a/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250701-0319.json
+++ b/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250701-0319.json
@@ -1,0 +1,52 @@
+[
+  {
+    "scenario_id": "dma-assessment_user_123_250616-0635",
+    "flow_type": "dma-pre-assessment",
+    "overall_score": 20,
+    "score_percentage": 100.0,
+    "assessment_min_score": 0,
+    "assessment_max_score": 20,
+    "turns": [
+      {
+        "question_name": null,
+        "question_number": 1,
+        "llm_utterance": "To what extent do you feel you can make decisions about your health?\n\n1. I strongly agree\n2. I agree\n3. I'm not sure\n4. I disagree\n5. I strongly disagree",
+        "user_utterance": "I strongly agree",
+        "user_response": "I strongly agree",
+        "score": 4
+      },
+      {
+        "question_name": null,
+        "question_number": 2,
+        "llm_utterance": "Do you feel comfortable talking about your health issues with a health worker?\n\n1. I strongly agree\n2. I agree\n3. I'm not sure\n4. I disagree\n5. I strongly disagree",
+        "user_utterance": "I strongly agree",
+        "user_response": "I strongly agree",
+        "score": 4
+      },
+      {
+        "question_name": null,
+        "question_number": 3,
+        "llm_utterance": "Can you disagree with a health worker about your treatment plan?\n\n1. I strongly agree\n2. I agree\n3. I'm not sure\n4. I disagree\n5. I strongly disagree",
+        "user_utterance": "I strongly agree",
+        "user_response": "I strongly agree",
+        "score": 4
+      },
+      {
+        "question_name": null,
+        "question_number": 4,
+        "llm_utterance": "I feel that I can do things to improve my health.\n\n1. I strongly agree\n2. I agree\n3. I'm not sure\n4. I disagree\n5. I strongly disagree",
+        "user_utterance": "I strongly agree",
+        "user_response": "I strongly agree",
+        "score": 4
+      },
+      {
+        "question_name": null,
+        "question_number": 5,
+        "llm_utterance": "Do you feel that you can find information about your health from other places, not just a health worker?\n\n1. I strongly agree\n2. I agree\n3. I'm not sure\n4. I disagree\n5. I strongly disagree",
+        "user_utterance": "I strongly agree",
+        "user_response": "I strongly agree",
+        "score": 4
+      }
+    ]
+  }
+]

--- a/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250701-0319.report.txt
+++ b/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250701-0319.report.txt
@@ -1,0 +1,41 @@
+
+==================================================
+              DETAILED TURN-BY-TURN REPORT
+==================================================
+
+--- Turn: dma-assessment_user_123_250616-0635 (dma-pre-assessment) | ID: 1 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: dma-assessment_user_123_250616-0635 (dma-pre-assessment) | ID: 2 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: dma-assessment_user_123_250616-0635 (dma-pre-assessment) | ID: 3 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: dma-assessment_user_123_250616-0635 (dma-pre-assessment) | ID: 4 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: dma-assessment_user_123_250616-0635 (dma-pre-assessment) | ID: 5 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+
+==================================================
+              PERFORMANCE SUMMARY REPORT
+==================================================
+
+📊 Dma-pre-assessment Performance (5 turns evaluated):
+  - Extraction Accuracy: 100.00%
+  - Question Consistency Score (Avg): 1.00
+  - Response Appropriateness Score (Avg): 1.00
+
+==================================================

--- a/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250701-0322.json
+++ b/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250701-0322.json
@@ -1,0 +1,136 @@
+[
+  {
+    "scenario_id": "behaviour-pre-assessment_user_123_250616-0635",
+    "flow_type": "behaviour-pre-assessment",
+    "overall_score": 6,
+    "score_percentage": 85.71,
+    "assessment_min_score": 0,
+    "assessment_max_score": 7,
+    "turns": [
+      {
+        "question_name": null,
+        "question_number": 1,
+        "llm_utterance": "During this pregnancy, how many times have you visited the clinic for a pregnancy check-up?",
+        "user_utterance": "3",
+        "user_response": "3",
+        "score": 3
+      },
+      {
+        "question_name": null,
+        "question_number": 2,
+        "llm_utterance": "In this pregnancy, have you made any changes to your diet based on information from a health worker?",
+        "user_utterance": "No",
+        "user_response": "No",
+        "score": 2
+      },
+      {
+        "question_name": null,
+        "question_number": 3,
+        "llm_utterance": "How many doses of the tetanus vaccine (Tdap) have you received during this pregnancy so far?\n\n0 or 1?",
+        "user_utterance": "1",
+        "user_response": "1",
+        "score": 1
+      },
+      {
+        "question_name": null,
+        "question_number": 4,
+        "llm_utterance": "Since becoming pregnant, have you consumed any alcohol or smoked at all?\n\nPlease reply with \"Yes\" or \"No\".",
+        "user_utterance": "Yes",
+        "user_response": "Yes",
+        "score": 0
+      }
+    ]
+  },
+  {
+    "scenario_id": "knowledge-pre-assessment_user_123_250616-0635",
+    "flow_type": "knowledge-pre-assessment",
+    "overall_score": 1,
+    "score_percentage": 16.67,
+    "assessment_min_score": 0,
+    "assessment_max_score": 6,
+    "turns": [
+      {
+        "question_name": null,
+        "question_number": 1,
+        "llm_utterance": "When should you schedule your first pregnancy check-up? \ud83e\udd30\ud83c\udffd\n\na. Before 14 weeks\nb. At about 16 weeks\nc. At about 20 weeks\nd. At about 24 weeks\ne. At birth\nf. I don't know",
+        "user_utterance": "Before 14 weeks",
+        "user_response": "Before 14 weeks",
+        "score": 0
+      },
+      {
+        "question_name": null,
+        "question_number": 2,
+        "llm_utterance": "During your pregnancy, which of these signs means you need to go to the hospital immediately? \ud83e\udd30\ud83c\udffd\n\na. You have contractions that stop when you move\nb. Your tummy stays tight, hard and is very painful\nc. Your lower back aches all day",
+        "user_utterance": "I don't know",
+        "user_response": "I don't know",
+        "score": 0
+      },
+      {
+        "question_name": null,
+        "question_number": 3,
+        "llm_utterance": "How many pregnancy check-ups should you attend during your pregnancy?\n\na. 1 to 4 check-ups\nb. 5 to 7 check-ups\nc. 8 or more check-ups\nd. 0 - None\ne. I don't know",
+        "user_utterance": "I don't know",
+        "user_response": "I don't know",
+        "score": 0
+      },
+      {
+        "question_name": null,
+        "question_number": 4,
+        "llm_utterance": "Should a baby be breastfed within the first hour of birth?",
+        "user_utterance": "yes",
+        "user_response": "Yes",
+        "score": 1
+      },
+      {
+        "question_name": null,
+        "question_number": 5,
+        "llm_utterance": "Who does this vaccine protect, you or your baby or both? \ud83e\udd30\ud83c\udffd\n\na. You\nb. Your baby only\nc. You and baby\nd. I don't know",
+        "user_utterance": "I don't know",
+        "user_response": "I don't know",
+        "score": 0
+      },
+      {
+        "question_name": null,
+        "question_number": 6,
+        "llm_utterance": "Are iron and folic acid supplements good for you and your unborn baby during pregnancy?",
+        "user_utterance": "No",
+        "user_response": "No",
+        "score": 0
+      }
+    ]
+  },
+  {
+    "scenario_id": "attitude-pre-assessment_user_123_250616-0635",
+    "flow_type": "attitude-pre-assessment",
+    "overall_score": 13,
+    "score_percentage": 86.67,
+    "assessment_min_score": 0,
+    "assessment_max_score": 15,
+    "turns": [
+      {
+        "question_name": null,
+        "question_number": 1,
+        "llm_utterance": "Do you agree that attending pregnancy check-ups is a good way to ensure the health of you and your unborn baby?\n\n1. I strongly agree\n2. I agree\n3. I'm not sure\n4. I disagree\n5. I strongly disagree",
+        "user_utterance": "I strongly agree",
+        "user_response": "I strongly agree",
+        "score": 5
+      },
+      {
+        "question_name": null,
+        "question_number": 2,
+        "llm_utterance": "Do you think home birth is safer than giving birth in a hospital?\n\n1. I strongly agree\n2. I agree\n3. I'm not sure\n4. I disagree\n5. I strongly disagree",
+        "user_utterance": "I disagree",
+        "user_response": "I disagree",
+        "score": 4
+      },
+      {
+        "question_name": null,
+        "question_number": 3,
+        "llm_utterance": "Is it important for a 33-year-old pregnant woman to get an HIV test when she is pregnant?\n\n1. I strongly agree\n2. I agree\n3. I'm not sure\n4. I disagree\n5. I strongly disagree",
+        "user_utterance": "I agree",
+        "user_response": "I agree",
+        "score": 4
+      }
+    ]
+  }
+]

--- a/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250701-0322.report.txt
+++ b/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250701-0322.report.txt
@@ -1,0 +1,92 @@
+
+==================================================
+              DETAILED TURN-BY-TURN REPORT
+==================================================
+
+--- Turn: behaviour-pre-assessment_user_123_250616-0635 (behaviour-pre-assessment) | ID: 1 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: behaviour-pre-assessment_user_123_250616-0635 (behaviour-pre-assessment) | ID: 2 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: behaviour-pre-assessment_user_123_250616-0635 (behaviour-pre-assessment) | ID: 3 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: behaviour-pre-assessment_user_123_250616-0635 (behaviour-pre-assessment) | ID: 4 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: knowledge-pre-assessment_user_123_250616-0635 (knowledge-pre-assessment) | ID: 1 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 0.83 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: knowledge-pre-assessment_user_123_250616-0635 (knowledge-pre-assessment) | ID: 2 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: knowledge-pre-assessment_user_123_250616-0635 (knowledge-pre-assessment) | ID: 3 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 0.83 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: knowledge-pre-assessment_user_123_250616-0635 (knowledge-pre-assessment) | ID: 4 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: knowledge-pre-assessment_user_123_250616-0635 (knowledge-pre-assessment) | ID: 5 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 0.75 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: knowledge-pre-assessment_user_123_250616-0635 (knowledge-pre-assessment) | ID: 6 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 0.00 ] Response Appropriateness
+       Reason: The score is 0.00 because the response 'no' does not address the question about the benefits of iron and folic acid supplements during pregnancy, making it entirely irrelevant to the input.
+
+--- Turn: attitude-pre-assessment_user_123_250616-0635 (attitude-pre-assessment) | ID: 1 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: attitude-pre-assessment_user_123_250616-0635 (attitude-pre-assessment) | ID: 2 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: attitude-pre-assessment_user_123_250616-0635 (attitude-pre-assessment) | ID: 3 ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+
+==================================================
+              PERFORMANCE SUMMARY REPORT
+==================================================
+
+📊 Behaviour-pre-assessment Performance (4 turns evaluated):
+  - Extraction Accuracy: 100.00%
+  - Question Consistency Score (Avg): 1.00
+  - Response Appropriateness Score (Avg): 1.00
+
+📊 Knowledge-pre-assessment Performance (6 turns evaluated):
+  - Extraction Accuracy: 100.00%
+  - Question Consistency Score (Avg): 0.90
+  - Response Appropriateness Score (Avg): 0.83
+
+📊 Attitude-pre-assessment Performance (3 turns evaluated):
+  - Extraction Accuracy: 100.00%
+  - Question Consistency Score (Avg): 1.00
+  - Response Appropriateness Score (Avg): 1.00
+
+==================================================

--- a/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250701-0324.json
+++ b/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250701-0324.json
@@ -1,0 +1,71 @@
+[
+  {
+    "scenario_id": "anc-survey_user_123_250616-0635",
+    "flow_type": "anc-survey",
+    "turns": [
+      {
+        "question_name": "start",
+        "question_number": null,
+        "llm_utterance": "Hello! Have you attended your prenatal check-up appointment this week yet? \ud83c\udfe5\n\nPlease reply with one of the following:\n- 'Yes, I went'\n- 'No, I'm not going'\n- 'I'm going soon'",
+        "user_utterance": "Yes",
+        "user_response": "Yes, I went"
+      },
+      {
+        "question_name": "Q_seen",
+        "question_number": null,
+        "llm_utterance": "Did a health worker attend to you during your prenatal appointment?",
+        "user_utterance": "Ya",
+        "user_response": "Yes"
+      },
+      {
+        "question_name": "seen_yes",
+        "question_number": null,
+        "llm_utterance": "We're glad you attended your prenatal appointment! \ud83c\udf89 Would you be able to spare 2 minutes to share how it went with us?\n\nPlease reply with one of the following:\n- 'Yes'\n- 'Remind me tomorrow'",
+        "user_utterance": "Ok",
+        "user_response": "Yes"
+      },
+      {
+        "question_name": "Q_bp",
+        "question_number": null,
+        "llm_utterance": "During your recent prenatal check-up, did the healthcare provider measure your blood pressure?",
+        "user_utterance": "I don't know",
+        "user_response": "I don't know"
+      },
+      {
+        "question_name": "Q_experience",
+        "question_number": null,
+        "llm_utterance": "Can you share how you felt about your overall experience at the check-up? You can choose from: 'Very good', 'Good', 'OK', 'Bad', 'Very bad'.\n\na. Very good\nb. Good\nc. OK\nd. Bad\ne. Very bad",
+        "user_utterance": "Cool",
+        "user_response": "OK"
+      },
+      {
+        "question_name": "good",
+        "question_number": null,
+        "llm_utterance": "Thank you for sharing your experience. There are just 2 more questions. Your answers to these will help us understand how we can make services better for pregnant women in South Africa. Would you like to continue?\n\nPlease reply with 'Continue' to continue.",
+        "user_utterance": "Yes",
+        "user_response": "Continue"
+      },
+      {
+        "question_name": "Q_visit_bad",
+        "question_number": null,
+        "llm_utterance": "Share with us what made you the most uncomfortable or caused you the biggest problem during your check-up by selecting one of the options below:\n\na. I didn't have my maternity record\ud83d\udcdd\nb. I was shamed or embarrassed \ud83d\ude33\nc. I was not given privacy to discuss my worries or challenges \ud83e\udd10\nd. I was not given enough information about tests, supplements or my pregnancy \u2139\ufe0f\ne. The staff were disrespectful \ud83e\udd2c\nf. They asked me to pay \ud83d\udcb0\ng. I had to wait a long time \u231b\nh. Something else \ud83d\ude1e",
+        "user_utterance": "had to wait long time",
+        "user_response": "Waited a long time \u231b"
+      },
+      {
+        "question_name": "Q_challenges",
+        "question_number": null,
+        "llm_utterance": "What has been your *biggest challenge* in attending these check-ups? \ud83e\udd14\n\na. No challenges - all fine\ud83d\udc4c\nb. Transport is expensive or it\u2019s far to travel \ud83d\ude8c\nc. I don't have support from my partner or family \ud83e\udd1d\nd. It's hard to get there during clinic opening hours \ud83c\udfe5\ne. Something else \ud83d\ude1e",
+        "user_utterance": "It's hard to get there during clinic opening hours \ud83c\udfe5",
+        "user_response": "Clinic opening hours \ud83c\udfe5"
+      },
+      {
+        "question_name": "intent",
+        "question_number": null,
+        "llm_utterance": "Thank you for taking the time to answer our questions! \ud83c\udf1f \n\nRemember, going to all your pregnancy check-ups is the best way to make sure that you and baby stay healthy \ud83d\udcaa\ud83c\udffd \n\nDuring pregnancy, your body changes a lot. The earlier a possible problem with you or baby is identified, the quicker it can be treated. \n\nDo you think you will go for your next check-up?",
+        "user_utterance": "Ja",
+        "user_response": "Yes, I will"
+      }
+    ]
+  }
+]

--- a/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250701-0324.report.txt
+++ b/src/ai4gd_momconnect_haystack/evaluation/data/simulation_run_results_250701-0324.report.txt
@@ -1,0 +1,66 @@
+
+==================================================
+              DETAILED TURN-BY-TURN REPORT
+==================================================
+
+--- Turn: anc-survey_user_123_250616-0635 (anc-survey) | ID: start ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 0.67 ] Question Consistency
+       Reason: The score is 0.67 because while the response partially addresses the question about the pregnancy check-up, it includes irrelevant elements like a general greeting and an instruction, which do not directly contribute to answering the query.
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: anc-survey_user_123_250616-0635 (anc-survey) | ID: Q_seen ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: anc-survey_user_123_250616-0635 (anc-survey) | ID: seen_yes ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 0.40 ] Question Consistency
+       Reason: The score is 0.40 because the output includes multiple response options and format prompts that do not directly address the input's request for feedback. However, the presence of these options indicates an attempt to engage with the input, which is why the score is not lower.
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: anc-survey_user_123_250616-0635 (anc-survey) | ID: Q_bp ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: anc-survey_user_123_250616-0635 (anc-survey) | ID: Q_experience ---
+  [❌] Extraction Accuracy: FAILED
+       Details: Expected: 'good', Got: 'ok'
+  [ score: 0.00 ] Question Consistency
+       Reason: The score is 0.00 because the output consists entirely of options for feedback rather than a direct description of the check-up experience, making it irrelevant to the input question.
+  [ score: 0.00 ] Response Appropriateness
+       Reason: The score is 0.00 because the response 'cool' does not align with the requested rating options ('very good', 'good', 'ok', 'bad', 'very bad'). It fails to provide a relevant answer to the input question.
+
+--- Turn: anc-survey_user_123_250616-0635 (anc-survey) | ID: good ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: anc-survey_user_123_250616-0635 (anc-survey) | ID: Q_visit_bad ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: anc-survey_user_123_250616-0635 (anc-survey) | ID: Q_challenges ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+--- Turn: anc-survey_user_123_250616-0635 (anc-survey) | ID: intent ---
+  [✅] Extraction Accuracy: PASSED
+  [ score: 1.00 ] Question Consistency
+  [ score: 1.00 ] Response Appropriateness
+
+
+==================================================
+              PERFORMANCE SUMMARY REPORT
+==================================================
+
+📊 Anc-survey Performance (9 turns evaluated):
+  - Extraction Accuracy: 88.89%
+  - Question Consistency Score (Avg): 0.79
+  - Response Appropriateness Score (Avg): 0.89
+
+==================================================

--- a/src/ai4gd_momconnect_haystack/main.py
+++ b/src/ai4gd_momconnect_haystack/main.py
@@ -77,6 +77,10 @@ GT_FILE_PATH = DATA_PATH / "evaluation" / "data" / "ground_truth.json"
 SERVICE_PERSONA_PATH = DATA_PATH / "static_content" / "service_persona.json"
 
 SERVICE_PERSONA = load_json_and_validate(SERVICE_PERSONA_PATH, dict)
+SERVICE_PERSONA_TEXT = ""
+if SERVICE_PERSONA:
+    if "persona" in SERVICE_PERSONA.keys():
+        SERVICE_PERSONA_TEXT = SERVICE_PERSONA["persona"]
 
 # Define which assessments from the doc stores are scorable
 SCORABLE_ASSESSMENTS = {
@@ -190,7 +194,7 @@ async def run_simulation(gt_scenarios: list[dict[str, Any]] | None = None):
                 print("Please enter 'Y' or 'N'.")
 
     if sim_onboarding:
-        chat_history.append(ChatMessage.from_system(text=SERVICE_PERSONA))
+        chat_history.append(ChatMessage.from_system(text=SERVICE_PERSONA_TEXT))
         # Simulate Onboarding
         flow_id = "onboarding"
         gt_scenario = gt_lookup_by_flow.get(flow_id)
@@ -1187,7 +1191,7 @@ async def run_simulation(gt_scenarios: list[dict[str, Any]] | None = None):
                         ChatHistory.user_id == user_id,
                     )
                 )
-        chat_history.append(ChatMessage.from_system(text=SERVICE_PERSONA))
+        chat_history.append(ChatMessage.from_system(text=SERVICE_PERSONA_TEXT))
         anc_user_context = {
             "age": user_context.get("age"),
             "gender": user_context.get("gender"),

--- a/src/ai4gd_momconnect_haystack/static_content/anc_survey.json
+++ b/src/ai4gd_momconnect_haystack/static_content/anc_survey.json
@@ -57,7 +57,7 @@
         },
         {
             "title": "bad",
-            "content": "We're sorry to hear you had a bad experience.\n\nBy telling us a bit more,  you can help us understand how to improve services for pregnant women in South Africa.",
+            "content": "We're sorry to hear you had a bad experience.\n\nBy telling us a bit more, you can help us understand how to improve services for pregnant women in South Africa.",
             "content_type": "follow_up_question",
             "valid_responses": [
                 "OK"

--- a/src/ai4gd_momconnect_haystack/static_content/assessment_ends.json
+++ b/src/ai4gd_momconnect_haystack/static_content/assessment_ends.json
@@ -15,13 +15,13 @@
                 "valid_responses": ["Next"]
             },
             "skipped-many-content": {
-                "content": "You skipped more than half the questions, so we can't tell how you feel about healthcare 😞\n\nIt would be great if you could answer them when you feel ready.\n\nCan we remind you tomorrow? Respond with 'Yes' or 'No'.",
+                "content": "You skipped more than half the questions, so we can't tell how you feel about healthcare 😞\n\nIt would be great if you could answer them when you feel ready.\n\nCan we remind you tomorrow?",
                 "valid_responses": ["Yes","No"]
             }
         },
         {
             "message_nr": 2,
-            "content": "You're finished! Thank you 🏆\n\n*Your life* 🗝️\n\n*Healthcare* ☀️\n\nHow easy was it to finish this?\n- Very easy\n- A little easy\n- OK\n- A little difficult\n- Very difficult",
+            "content": "You're finished! Thank you 🏆\n\n*Your life* 🗝️\n\n*Healthcare* ☀️\n\nHow easy was it to finish this?\na. Very easy\nb. A little easy\nc. OK\nd. A little difficult\ne. Very difficult",
             "valid_responses": [
                 "Very easy",
                 "A little easy",
@@ -39,19 +39,19 @@
         {
             "message_nr": 1,
             "high-score-content": {
-                "content": "*Pregnancy Health Check*\n💜⚪⚪\n\nThank you for sharing! You're making healthy decisions for you and your unborn child 💪🏽\n\nRemember:\n\n• A healthy pregnancy needs healthy foods. Follow the health worker's advice 🥬🥚🥛🍎\n\n• And stay away from alcohol and cigarettes while you are pregnant or breastfeeding. It can harm your baby 🚬🍷\n\nAre you ready to move on to a few more questions? 👇🏽\n\nRespond with 'Yes' or 'Remind me tomorrow'",
+                "content": "*Pregnancy Health Check*\n💜⚪⚪\n\nThank you for sharing! You're making healthy decisions for you and your unborn child 💪🏽\n\nRemember:\n\n• A healthy pregnancy needs healthy foods. Follow the health worker's advice 🥬🥚🥛🍎\n\n• And stay away from alcohol and cigarettes while you are pregnant or breastfeeding. It can harm your baby 🚬🍷\n\nAre you ready to move on to a few more questions? 👇🏽\n\nReply with 'Yes' or 'Remind me tomorrow'",
                 "valid_responses": ["Yes","Remind me tomorrow"]
             },
             "medium-score-content": {
-                "content": "*Pregnancy Health Check*\n💜⚪⚪\n\nThank you for sharing.\n\nIt's important to have correct information so that you can make good decisions for you and your unborn child.\n\nYou know you can always get trustworthy information from MomConnect\n\nHere are some top tips about a healthy pregnancy:\n\n• A healthy pregnancy needs healthy foods. Follow the health worker's advice 🥬🥚🥛🍎\n\n• And stay away from alcohol and cigarettes while you are pregnant or breastfeeding. It can harm your baby 🚬🍷\n\nAre you ready to move on to a few more questions? 👇🏽\n\nRespond with 'Yes' or 'Remind me tomorrow'",
+                "content": "*Pregnancy Health Check*\n💜⚪⚪\n\nThank you for sharing.\n\nIt's important to have correct information so that you can make good decisions for you and your unborn child.\n\nYou know you can always get trustworthy information from MomConnect\n\nHere are some top tips about a healthy pregnancy:\n\n• A healthy pregnancy needs healthy foods. Follow the health worker's advice 🥬🥚🥛🍎\n\n• And stay away from alcohol and cigarettes while you are pregnant or breastfeeding. It can harm your baby 🚬🍷\n\nAre you ready to move on to a few more questions? 👇🏽\n\nReply with 'Yes' or 'Remind me tomorrow'",
                 "valid_responses": ["Yes","Remind me tomorrow"]
             },
             "low-score-content": {
-                "content": "*Pregnancy Health Check*\n💜⚪⚪\n\nThank you for sharing.\n\nIt's important to have correct information so that you can make good decisions for you and your unborn child.\n\nYou know you can always get trustworthy information from MomConnect.\n\nHere are some top tips about a healthy pregnancy:\n\n• A healthy pregnancy needs healthy foods. Follow the health worker's advice 🥬🥚🥛🍎\n\n• And stay away from alcohol and cigarettes while you are pregnant or breastfeeding. It can harm your baby 🚬🍷\n\nAre you ready to move on to a few more questions? 👇🏽\n\nRespond with 'Yes' or 'Remind me tomorrow'",
+                "content": "*Pregnancy Health Check*\n💜⚪⚪\n\nThank you for sharing.\n\nIt's important to have correct information so that you can make good decisions for you and your unborn child.\n\nYou know you can always get trustworthy information from MomConnect.\n\nHere are some top tips about a healthy pregnancy:\n\n• A healthy pregnancy needs healthy foods. Follow the health worker's advice 🥬🥚🥛🍎\n\n• And stay away from alcohol and cigarettes while you are pregnant or breastfeeding. It can harm your baby 🚬🍷\n\nAre you ready to move on to a few more questions? 👇🏽\n\nReply with 'Yes' or 'Remind me tomorrow'",
                 "valid_responses": ["Yes","Remind me tomorrow"]
             },
             "skipped-many-content": {
-                "content": "We noticed you skipped some of the questions in this section. We can remind you about them tomorrow.\n\nThere are 8 more new questions to do in this health check. Do you want to do them now and finish it?\n\nRespond with 'Yes' or 'Remind me tomorrow'",
+                "content": "We noticed you skipped some of the questions in this section. We can remind you about them tomorrow.\n\nThere are 8 more new questions to do in this health check. Do you want to do them now and finish it?\n\nReply with 'Yes' or 'Remind me tomorrow'",
                 "valid_responses": ["Yes","Remind me tomorrow"]
             }
         }
@@ -60,19 +60,19 @@
         {
             "message_nr": 1,
             "high-score-content": {
-                "content": "*Pregnancy Health Check*\n💜💙⚪\n\nThank you for taking the time to answer these! You know a lot about healthy pregnancy 🙌🏽\n\n*Here are the main points*\n• It's best to go to the clinic as soon as you know you're pregnant. This first pregnancy check-up should be before 14 weeks. You should have 8 or more check-ups in total 🏥\n\n• If your tummy stays tight, hard and is very painful you need to go to the clinic 🤰🏾\n\n• At your pregnancy check-ups, you should get the tetanus vaccine. This helps protect you and your baby after birth 💉\n\n• Iron and folic acid supplements are important for you and your unborn baby 💪🏽\n\nYou ready for the last 3 pregnancy questions? 👇🏽\n\nRespond with 'Yes' or 'Remind me tomorrow'",
+                "content": "*Pregnancy Health Check*\n💜💙⚪\n\nThank you for taking the time to answer these! You know a lot about healthy pregnancy 🙌🏽\n\n*Here are the main points*\n• It's best to go to the clinic as soon as you know you're pregnant. This first pregnancy check-up should be before 14 weeks. You should have 8 or more check-ups in total 🏥\n\n• If your tummy stays tight, hard and is very painful you need to go to the clinic 🤰🏾\n\n• At your pregnancy check-ups, you should get the tetanus vaccine. This helps protect you and your baby after birth 💉\n\n• Iron and folic acid supplements are important for you and your unborn baby 💪🏽\n\nYou ready for the last 3 pregnancy questions? 👇🏽\n\nReply with 'Yes' or 'Remind me tomorrow'",
                 "valid_responses": ["Yes","Remind me tomorrow"]
             },
             "medium-score-content": {
-                "content": "*Pregnancy Health Check*\n💜💙⚪\n\nThank you for taking the time to answer these! MomConnect can help you boost your knowledge about healthy pregnancy.\n\n• It's best to go to the clinic as soon as you know you're pregnant. This first pregnancy check-up should be before 14 weeks. You should have 8 or more check-ups in total 🏥\n\n• If your tummy stays tight, hard and is very painful you need to go to the clinic 🤰🏾\n\n• At your pregnancy check-ups, you should get the tetanus vaccine. This helps protect you and baby after birth 💉\n\n• Iron and folic acid supplements are important for you and your unborn baby 💪🏽\n\nYou ready for the last 3 pregnancy questions? 👇🏽\n\nRespond with 'Yes' or 'Remind me tomorrow'",
+                "content": "*Pregnancy Health Check*\n💜💙⚪\n\nThank you for taking the time to answer these! MomConnect can help you boost your knowledge about healthy pregnancy.\n\n• It's best to go to the clinic as soon as you know you're pregnant. This first pregnancy check-up should be before 14 weeks. You should have 8 or more check-ups in total 🏥\n\n• If your tummy stays tight, hard and is very painful you need to go to the clinic 🤰🏾\n\n• At your pregnancy check-ups, you should get the tetanus vaccine. This helps protect you and baby after birth 💉\n\n• Iron and folic acid supplements are important for you and your unborn baby 💪🏽\n\nYou ready for the last 3 pregnancy questions? 👇🏽\n\nReply with 'Yes' or 'Remind me tomorrow'",
                 "valid_responses": ["Yes","Remind me tomorrow"]
             },
             "low-score-content": {
-                "content": "*Pregnancy Health Check*\n💜💙⚪\n\nThank you for taking the time to answer these! MomConnect can help you boost your knowledge about healthy pregnancy.\n\n• It's best to go to the clinic as soon as you know you're pregnant. This first pregnancy check-up should be before 14 weeks. You should have 8 or more check-ups in total 🏥\n\n• If your tummy stays tight, hard and is very painful you need to go to the clinic 🤰🏾\n\n• At your pregnancy check-ups, you should get the tetanus vaccine. This helps protect you and your baby after birth 💉\n\n• Iron and folic acid supplements are important for you and your unborn baby 💪🏽\n\nYou ready for the last 3 pregnancy questions? 👇🏽\n\nRespond with 'Yes' or 'Remind me tomorrow'",
+                "content": "*Pregnancy Health Check*\n💜💙⚪\n\nThank you for taking the time to answer these! MomConnect can help you boost your knowledge about healthy pregnancy.\n\n• It's best to go to the clinic as soon as you know you're pregnant. This first pregnancy check-up should be before 14 weeks. You should have 8 or more check-ups in total 🏥\n\n• If your tummy stays tight, hard and is very painful you need to go to the clinic 🤰🏾\n\n• At your pregnancy check-ups, you should get the tetanus vaccine. This helps protect you and your baby after birth 💉\n\n• Iron and folic acid supplements are important for you and your unborn baby 💪🏽\n\nYou ready for the last 3 pregnancy questions? 👇🏽\n\nReply with 'Yes' or 'Remind me tomorrow'",
                 "valid_responses": ["Yes","Remind me tomorrow"]
             },
             "skipped-many-content": {
-                "content": "We noticed you skipped some of the questions in this section. We can remind you about them tomorrow.\n\nThere are 3 new questions to do in this health check. Do you want to do them now and finish it?\n\nRespond with 'Yes' or 'Remind me tomorrow'",
+                "content": "We noticed you skipped some of the questions in this section. We can remind you about them tomorrow.\n\nThere are 3 new questions to do in this health check. Do you want to do them now and finish it?\n\nReply with 'Yes' or 'Remind me tomorrow'",
                 "valid_responses": ["Yes","Remind me tomorrow"]
             }
         }
@@ -81,7 +81,7 @@
         {
             "message_nr": 1,
             "high-score-content": {
-                "content": "*Pregnancy Health Check*\n💜💙💛\n\nThank you for answering all these questions! You have completed all the questions and you know a lot about healthy pregnancy.\n\n*Remember*\n• Keep going to your pregnancy check-ups. This is important for you and baby 🏥\n\n• Try to plan to give birth at a clinic or hospital - it's generally safer. If not, have a skilled birth attendant to help you at the birth 💛\n\n• Get an HIV test when you have your pregnancy check-up. Early treatment can keep you healthy and protect baby 👶🏽\n\nThank you, you've completed the health check!\n\n*How easy was it to complete this?*\n- Very easy\n- A little easy\n- OK\n- A little difficult\n- Very difficult",
+                "content": "*Pregnancy Health Check*\n💜💙💛\n\nThank you for answering all these questions! You have completed all the questions and you know a lot about healthy pregnancy.\n\n*Remember*\n• Keep going to your pregnancy check-ups. This is important for you and baby 🏥\n\n• Try to plan to give birth at a clinic or hospital - it's generally safer. If not, have a skilled birth attendant to help you at the birth 💛\n\n• Get an HIV test when you have your pregnancy check-up. Early treatment can keep you healthy and protect baby 👶🏽\n\nThank you, you've completed the health check!\n\n*How easy was it to complete this?*\na. Very easy\nb. A little easy\nc. OK\nd. A little difficult\ne. Very difficult",
                 "valid_responses": [
                     "Very easy",
                     "A little easy",
@@ -91,7 +91,7 @@
                 ]
             },
             "medium-score-content": {
-                "content": "*Pregnancy Health Check*\n💜💙💛\n\nThank you for answering all these questions! When you have all the correct information, you can make the best decisions for you and baby.\n\n*Remember*\n• Keep going to to your pregnancy check-ups. This is important for you and baby 🏥\n\n• Try to plan to give birth in a clinic or hospital - it's generally safer. If not, have a skilled birth attendant to help you at the birth 💛\n\n• Get an HIV test at your pregnancy check-up. Early treatment can keep you healthy and protect the baby 👶🏽\n\nThank you, you've completed the health check!\n\n*How easy was it to complete this?*\n- Very easy\n- A little easy\n- OK\n- A little difficult\n- Very difficult",
+                "content": "*Pregnancy Health Check*\n💜💙💛\n\nThank you for answering all these questions! When you have all the correct information, you can make the best decisions for you and baby.\n\n*Remember*\n• Keep going to to your pregnancy check-ups. This is important for you and baby 🏥\n\n• Try to plan to give birth in a clinic or hospital - it's generally safer. If not, have a skilled birth attendant to help you at the birth 💛\n\n• Get an HIV test at your pregnancy check-up. Early treatment can keep you healthy and protect the baby 👶🏽\n\nThank you, you've completed the health check!\n\n*How easy was it to complete this?*\na. Very easy\nb. A little easy\nc. OK\nd. A little difficult\ne. Very difficult",
                 "valid_responses": [
                     "Very easy",
                     "A little easy",
@@ -101,7 +101,7 @@
                 ]
             },
             "low-score-content": {
-                "content": "*Pregnancy Health Check*\n💜💙💛\n\nThank you for answering all these questions! When you have all the correct information, you can make the best decisions for you and baby.\n\n*Remember*\n• Keep going to to your pregnancy check-ups. This is important for you and your baby 🏥\n\n• Try to plan to give birth in a clinic or hospital - it's generally safer. If not, have a skilled birth attendant to help you at the birth 💛\n\n• Get an HIV test at your pregnancy check-up. Early treatment can keep you healthy and protect the baby 👶🏽\n\nThank you, you've completed the health check!\n\n*How easy was it to complete this?*\n- Very easy\n- A little easy\n- OK\n- A little difficult\n- Very difficult",
+                "content": "*Pregnancy Health Check*\n💜💙💛\n\nThank you for answering all these questions! When you have all the correct information, you can make the best decisions for you and baby.\n\n*Remember*\n• Keep going to to your pregnancy check-ups. This is important for you and your baby 🏥\n\n• Try to plan to give birth in a clinic or hospital - it's generally safer. If not, have a skilled birth attendant to help you at the birth 💛\n\n• Get an HIV test at your pregnancy check-up. Early treatment can keep you healthy and protect the baby 👶🏽\n\nThank you, you've completed the health check!\n\n*How easy was it to complete this?*\na. Very easy\nb. A little easy\nc. OK\nd. A little difficult\ne. Very difficult",
                 "valid_responses": [
                     "Very easy",
                     "A little easy",
@@ -111,7 +111,7 @@
                 ]
             },
             "skipped-many-content": {
-                "content": "We noticed you skipped some of your questions.\n\nCan we remind you to answer them again tomorrow? Respond with 'Yes' or 'No'.",
+                "content": "We noticed you skipped some of your questions.\n\nCan we remind you to answer them again tomorrow? Reply with 'Yes' or 'No'.",
                 "valid_responses": ["Yes","No"]
             }
         },

--- a/src/ai4gd_momconnect_haystack/static_content/kab.json
+++ b/src/ai4gd_momconnect_haystack/static_content/kab.json
@@ -84,7 +84,7 @@
         {
             "question_number": 2,
             "question_name": "emergency_symptom_recognition",
-            "content": "*During a pregnancy, which of these means you need to go to the hospital immediately?* 🤰🏽\n\n• You have contractions that stop when you move\n• Your tummy stays tight, hard and is very painful\n• Your lower back aches all day",
+            "content": "*During a pregnancy, which of these means you need to go to the hospital immediately?* 🤰🏽",
             "content_type": "assessment_question",
             "valid_responses_and_scores": [
                 { "response": "Contractions stop", "score": 0 },

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -212,7 +212,7 @@ async def test_get_assessment_question():
             user_context={},
         )
         assert result == {
-            "contextualized_question": "mock_question",
+            "contextualized_question": "mock_question\n\n1. I strongly agree\n2. I agree\n3. I'm not sure\n4. I disagree\n5. I strongly disagree",
         }
 
         mock_create_pipeline.assert_called_once()
@@ -245,7 +245,7 @@ async def test_get_last_assessment_question():
             user_context={},
         )
         assert result == {
-            "contextualized_question": "mock_question",
+            "contextualized_question": "mock_question\n\n1. I strongly agree\n2. I agree\n3. I'm not sure\n4. I disagree\n5. I strongly disagree",
         }
 
         # This call should fail before the pipeline is even created or run,


### PR DESCRIPTION
### Changes in this PR

_These changes are aimed to improve user friendliness. While I would have loved to code some of these changes in a more structured/granularized/parsimonious way, such optimizations can wait for post-user-testing._

`static_content/`
- Modified some source content pieces to NOT contain their expected responses anymore. The expected responses are now, in a more hardcoded fashion, being formatted and inserted differently into 1) contextualized questions, and 2) system prompts for response validation/data extraction. This is to enforce a more user friendly journey and to enhance data extraction.

`api.py`
- The service persona being added to the first system prompt in a `ChatHistory` erroneously used a whole dictionary instead of just the value in the "persona" key. This has been fixed.
- Added a line in each of `/onboarding` and `/survey` endpoints to delete the user's corresponding `ChatHistory` when these endpoints are called with an empty string, which is our way of triggering the journey for the user.
  - For the full deployment, we can introduce versioning of our data instead of deleting the pre-existing data.
  - This change ensures that journeys can restart with a 'clean slate' easily, which is also a precautionary measure for user testing that's happening today.
- Similarly, when the `/assessments` endpoint is triggered with an empty string, we delete the associated assessment's data for that user.

`assessment_logic.py`
- Modified `validate_assessment_answer()` to use valid responses that are formatted in a friendly way for the system prompt to validate a user response.

`crud.py`
- Added two deletion functions to delete easily delete:
  - a user's `ChatHistory` for a given `HistoryType`
  - a user's `AssessmentHistory`, `AssessmentResultHistory` and `AssessmentEndMessagingHistory` for a given `AssessmentType`

`main.py`
- Better implementation of the service persona, as also seen in `api.py`

`pipelines.py`
- A variety of minor improvements to system prompts
- Minor changes made to implement the usage of one set of valid responses in the case of creating contextualized questions, and another in the case of creating a system prompt for data extraction/validation
- A bug fix in `run_assessment_end_response_validator_pipeline()` that extracted the validated response from the pipeline's `run` result incorrectly

`tasks.py`
- Implemented logic to help process valid responses into specific formats

`utilities.py`
- Added a variety of functions to help process valid responses into specific formats