### PR TITLE
bugfix

### DIFF
--- a/src/ai4gd_momconnect_haystack/assessment_logic.py
+++ b/src/ai4gd_momconnect_haystack/assessment_logic.py
@@ -347,7 +347,7 @@ def score_assessment(
         if skip_count > 2:
             crossed_skip_threshold = True
     else:
-        if score_percentage >= 100:
+        if score_percentage == 100:
             category = "high"
         elif score_percentage >= 75:
             category = "medium"

--- a/src/ai4gd_momconnect_haystack/static_content/kab.json
+++ b/src/ai4gd_momconnect_haystack/static_content/kab.json
@@ -25,7 +25,7 @@
             "content_type": "assessment_question",
             "valid_responses_and_scores": [
                 { "response": "Yes", "score": 1 },
-                { "response": "No", "score": 2 },
+                { "response": "No", "score": 0 },
                 { "response": "Skip", "score": 0 }
             ]
         },


### PR DESCRIPTION
### Fix: Corrects assessment scoring and final message

**What does this PR do?**

This PR fixes a bug where users received an incorrect final message in the `behaviour-pre-assessment`. An incorrect score value in `kab.json` caused the total score percentage to be miscalculated, assigning users who achieved a perfect score to the `medium` category instead of `high`.

**Changes:**

* **`kab.json`**: Corrected the score for `"No"` on `Question_number: 2` from `2` to `0`.
* **`assessment_logic.py`**: Hardened the check for a perfect score to `score_percentage == 100`.

---

### Verification

To test, run the `behaviour-pre-assessment` with the following answers to achieve a perfect score:

| Question | Answer |
| :--- | :---: |
| 1. ...times have you visited the clinic... | `7` |
| 2. ...made any adjustments to your diet... | `yes` |
| 3. ...doses of the tetanus vaccine... | `1` |
| 4. ...consumed any alcohol or smoked... | `No` |

**Score Calculation:**

* **Before Fix (main branch):** The max score for Q2 was incorrectly calculated as `2`, leading to the wrong denominator.
    * `score = (3+1+1+1) / (3+2+1+1) = 6 / 7 = 85.7%` -> **Incorrectly `medium`**

* **After Fix (this branch):** The max score is now correct.
    * `score = (3+1+1+1) / (3+1+1+1) = 6 / 6 = 100%` -> **Correctly `high`**