### PR TITLE
updated CLINIC_VISIT_DATA_EXTRACTION_PROMPT

### DIFF
--- a/src/ai4gd_momconnect_haystack/main.py
+++ b/src/ai4gd_momconnect_haystack/main.py
@@ -435,8 +435,7 @@ async def run_simulation(gt_scenarios: list[dict[str, Any]] | None = None):
             )
 
             print(f"Question #: {question_number}")
-            print(f"Question: {contextualized_question}")
-
+            # print(f"Question: {contextualized_question}")
             has_deflected = False
             final_user_response = None
             initial_predicted_intent = None
@@ -881,8 +880,7 @@ async def run_simulation(gt_scenarios: list[dict[str, Any]] | None = None):
 
                 print("-" * 20)
                 print(f"Question #: {question_number}")
-                print(f"Question: {contextualized_question}")
-
+                # print(f"Question: {contextualized_question}")
                 has_deflected = False
                 final_user_response = None
                 initial_predicted_intent = None
@@ -1317,8 +1315,7 @@ async def run_simulation(gt_scenarios: list[dict[str, Any]] | None = None):
 
             print("-" * 20)
             print(f"Question title: {question_identifier}")
-            print(f"Question: {contextualized_question}")
-
+            # print(f"Question: {contextualized_question}")
             has_deflected = False
             final_user_response = None
             initial_predicted_intent = None

--- a/src/ai4gd_momconnect_haystack/pipeline_prompts.py
+++ b/src/ai4gd_momconnect_haystack/pipeline_prompts.py
@@ -148,8 +148,8 @@ Your task is to analyze the user's response in light of the previous survey ques
 
 Follow these rules:
 1.  Map responses based on meaning and intent, not just exact string matching. This includes slang, colloquialisms, synonyms, and shortened versions.
-2.  If the user's response clearly maps to one of the expected responses, the value for "validated_response" MUST be the exact text of that matched expected response.
-3.  If the user's response is nonsense, gibberish, or completely unrelated to the question, you MUST set the value of "validated_response" to "nonsense".
+2.  The value for "validated_response" MUST be the exact text of the matched expected response.
+3.  If the options are presented in a lettered or numbered list (e.g., 'a.', '1.'), you MUST strip this prefix from your response. The `validated_response` should contain ONLY the text of the option itself.
 4.  You MUST respond with a valid JSON object with a single key, "validated_response".
 
 Here are some examples of how to perform this task:
@@ -226,6 +226,22 @@ User's latest response:
 JSON Response:
 {
     "validated_response": "nonsense"
+}
+---
+**Example 6 (Handling Lettered Lists):**
+
+
+Previous survey question/message:
+"Overall, how easy was it for you to provide your feedback?
+a. Very easy
+b. A little easy
+c. OK"
+
+User's latest response:
+- "a"
+JSON Response:
+{
+ "validated_response": "Very easy"
 }
 ---
 


### PR DESCRIPTION
## BugFix: Update Clinic Visit Data Extraction Prompt to Handle Lettered Lists

### The Issue
The `run_clinic_visit_data_extraction_pipeline` was failing when processing user responses that included the lettered prefix of an option (e.g., a., b.). As shown in the "before" logs, when a user responded with the full option text including its prefix (e.g., "a. Very easy"), the model would return the entire string. This caused the `JsonSchemaValidator` to fail because it expected only the option's text ("Very easy") to match the enum of valid responses. This led to unnecessary retries and a poor user experience.

### The Resolution
This PR resolves the issue by making the `CLINIC_VISIT_DATA_EXTRACTION_PROMPT` more explicit.

- **Added a New Rule:** A new rule (Rule 3) was added to instruct the LLM to strip any lettered or numbered prefixes from its final `validated_response`.

- **Added a New Example:** Example 6 was added to demonstrate this rule, showing that for a user input of `"a"`, the expected JSON output for `validated_response` is `"Very easy"`.

These changes ensure the model's output consistently matches the required schema, handling these inputs correctly on the first attempt and creating a smoother conversational flow.

#### Before Fix (Log) run ANC simulation:

```
{before fix: run on main}
> docker-compose run --remove-orphans python-app
[+] Creating 2/2
 ✔ Container ai4gd-momconnect-haystack-python-app-run-6c8552438300  Removed                                                              0.1s 
 ✔ Container ai4gd-momconnect-haystack-weaviate-1                   Running                                                              0.0s 
Simulate Onboarding? (Y/N)
> N

Simulate DMA? (Y/N)
> N

Simulate KAB? (Y/N)
> N


Simulate ANC Survey? (Y/N)
> Y
--------------------

--------------------

Question title: start
Question: Hi there 👋🏽 Did you attend your *pregnancy check-up* this week? 🏥


Please reply with one of the following:
- 'Yes, I went'
- 'No, I'm not going'
- 'I'm going soon'

> yes
Use_response: yes
Predicted Intent: JOURNEY_RESPONSE
[Extracted ANC Data]:
"Yes, I went"

--------------------

--------------------

Question title: Q_seen
Question: Did the health worker see you during the appointment?

> No
Use_response: No

Predicted Intent: JOURNEY_RESPONSE
[Extracted ANC Data]:
"No"

--------------------


Question title: Q_seen_no
Question: We're sorry to hear that. Can you please share what happened during the appointment?
Please reply with one of the following:
- 'Yes'
- 'Remind me tomorrow'

> Yes
Use_response: Yes

Predicted Intent: JOURNEY_RESPONSE
[Extracted ANC Data]:
"Yes"

--------------------


Question title: Q_why_no_visit
Question: Could you share the main reason why you didn't get to see a health worker when you went to the clinic?

a. The clinic was closed ⛔
b. I had to wait too long⌛
c. I didn't have my maternity record 📝
d. They asked me to pay💰
e. I was told to come back another day 📅
f. I left because the staff were disrespectful 🤬
g. Something else 😞


> a
Use_response: a

Predicted Intent: JOURNEY_RESPONSE
[Extracted ANC Data]:
"Clinic was closed \u26d4"

--------------------

Question title: intent
Question: Considering the importance of your pregnancy check-ups, and the changes your body goes through during pregnancy, do you plan to attend your next check-up?

> yes
Use_response: yes

Predicted Intent: JOURNEY_RESPONSE
[Extracted ANC Data]:
"Yes, I will"

--------------------

Question title: feedback_if_first_survey
Question: How did you find answering these questions? Was it very easy, a little easy, okay, a little difficult, or very difficult?

a. Very easy
b. A little easy
c. OK
d. A little difficult
e. Very difficult

Use_response: a. Very easy
Predicted Intent: JOURNEY_RESPONSE

2025-07-08 11:32:21,094 - WARNING - Clinic visit data extraction failed. LLM output did not match schema for user response: 'a. Very easy'. Result: {'json_validator': {'validation_error': [ChatMessage(_role=<ChatRole.USER: 'user'>, _content=[TextContent(text='The following generated JSON does not conform to the provided schema.\nGenerated JSON: {\n    "validated_response": "a. Very easy"\n}\nError details:\n- Message: \'a. Very easy\' is not one of [\'Very easy\', \'A little easy\', \'OK\', \'A little difficult\', \'Very difficult\', \'nonsense\']\n\nFailed validating \'enum\' in schema[\'properties\'][\'validated_response\']:\n    {\'type\': \'string\',\n     \'description\': \'The validated response from the user.\',\n     \'enum\': [\'Very easy\',\n              \'A little easy\',\n              \'OK\',\n              \'A little difficult\',\n              \'Very difficult\',\n              \'nonsense\']}\n\nOn instance[\'validated_response\']:\n    \'a. Very easy\'\n- Error Path in JSON: validated_response\n- Schema Path: properties -> validated_response -> enum\nPlease match the following schema:\n{\'type\': \'object\', \'properties\': {\'validated_response\': {\'type\': \'string\', \'description\': \'The validated response from the user.\', \'enum\': [\'Very easy\', \'A little easy\', \'OK\', \'A little difficult\', \'Very difficult\', \'nonsense\']}}, \'required\': [\'validated_response\']}\nand provide the corrected JSON content ONLY. Please do not output anything else than the raw corrected JSON string, this is the most important part of the task. Don\'t use any markdown and don\'t add any comment.')], _name=None, _meta={})]}}

2025-07-08 11:32:21,095 - WARNING - ANC data extraction pipeline did not produce a result.

--------------------


Question title: feedback_if_first_survey
Question: Before you go, can I ask you one last thing? *How did you find answering these questions?* Did you find it very easy, a little easy, okay, a little difficult, or very difficult?

a. Very easy
b. A little easy
c. OK
d. A little difficult
e. Very difficult

> a
Use_response: a

Predicted Intent: JOURNEY_RESPONSE
[Extracted ANC Data]:
"Very easy"


--------------------

Question title: end_if_feedback

Question: Thanks for your feedback. We'll be back with some more questions in the next few weeks! 💕

> okay
Use_response: okay

Predicted Intent: JOURNEY_RESPONSE

[Extracted ANC Data]:
"okay"

--------------------

2025-07-08 11:32:43,742 - WARNING - End of survey reached! Last step was: end_if_feedback

_________ COMPLETED SIMULATION__________

sys:1: ResourceWarning: unclosed <ssl.SSLSocket fd=8, family=2, type=1, proto=6, laddr=('172.18.0.4', 33850), raddr=('35.156.70.202', 443)>

~/reach/ai4gd-momconnect-haystack  main *2 ?1 ---------------------------------------------------------------------------- 1m 37s  13:32:44 

> 



{after fix: change to this branch}:



> git checkout DELTA-3402                       
Switched to branch 'DELTA-3402'

Your branch is up to date with 'origin/DELTA-3402'.
 ~/reach/ai4gd-momconnect-haystack  DELTA-3402 *2 ?1 ------------------------------------------------------------------------------ 13:33:32 

> docker-compose run --remove-orphans python-app

[+] Creating 2/2

 ✔ Container ai4gd-momconnect-haystack-python-app-run-e32acb7ae4c1  Removed                                                              0.1s 

 ✔ Container ai4gd-momconnect-haystack-weaviate-1                   Running                                                              0.0s 

Simulate Onboarding? (Y/N)
> N

Simulate DMA? (Y/N)
> N


Simulate KAB? (Y/N)
> N

Simulate ANC Survey? (Y/N)

> Y

--------------------

2025-07-08 11:33:51,450 - WARNING - Contextualization pipeline failed to produce a valid structured response. Falling back to original question.

--------------------

[everything is the same beside the last Q, feedback_if_first_survey]

Question title: feedback_if_first_survey
Question: How did you find answering these questions today?

a. Very easy
b. A little easy
c. OK
d. A little difficult
e. Very difficult

How did you find answering these questions today?

Use_response: a. Very easy
Predicted Intent: JOURNEY_RESPONSE

[Extracted ANC Data]:
"Very easy"



--------------------
2025-07-08 11:34:46,497 - WARNING - Contextualization pipeline failed to produce a valid structured response. Falling back to original question.

--------------------
Question title: end_if_feedback
Question: Thanks for your feedback. We'll be back with some more questions in the next few weeks! 💕
Click on this link to go to MomConnect: https://wa.me/27796312456

> okay
Use_response: okay
Predicted Intent: JOURNEY_RESPONSE
[Extracted ANC Data]:
"okay"

--------------------
2025-07-08 11:34:51,435 - WARNING - End of survey reached! Last step was: end_if_feedback
_________ COMPLETED SIMULATION__________

 ~/reach/ai4gd-momconnect-haystack  DELTA-3402 *2 ?1 ---------------------------------------------------------------------- 1m 16s  13:34:52 

> 
```
