### PR TITLE
Return processed_answer on assessments to save

### DIFF
--- a/src/ai4gd_momconnect_haystack/api.py
+++ b/src/ai4gd_momconnect_haystack/api.py
@@ -185,6 +185,8 @@ async def assessment(request: AssessmentRequest, token: str = Depends(verify_tok
         await delete_assessment_history_for_user(request.user_id, request.flow_id)
         intent, intent_related_response = "JOURNEY_RESPONSE", ""
 
+    processed_answer = None
+
     if intent == "JOURNEY_RESPONSE" and request.user_input:
         answer = validate_assessment_answer(
             user_response=request.user_input,
@@ -192,6 +194,7 @@ async def assessment(request: AssessmentRequest, token: str = Depends(verify_tok
             current_flow_id=request.flow_id.value,
         )
         if answer["processed_user_response"]:
+            processed_answer = answer["processed_user_response"]
             score = score_assessment_question(
                 answer["processed_user_response"],
                 request.question_number,
@@ -234,6 +237,7 @@ async def assessment(request: AssessmentRequest, token: str = Depends(verify_tok
         next_question=next_question_number,
         intent=intent,
         intent_related_response=intent_related_response,
+        processed_answer=processed_answer,
     )
 
 

--- a/src/ai4gd_momconnect_haystack/pydantic_models.py
+++ b/src/ai4gd_momconnect_haystack/pydantic_models.py
@@ -161,6 +161,7 @@ class AssessmentResponse(BaseModel):
     next_question: int
     intent: str | None
     intent_related_response: str | None
+    processed_answer: str | None
 
 
 class AssessmentEndRequest(BaseModel):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -318,6 +318,7 @@ async def test_assessment_chitchat(
         "next_question": 1,
         "intent": "CHITCHAT",
         "intent_related_response": "User is chitchatting",
+        "processed_answer": None,
     }
 
     handle_user_message.assert_called_once_with("How are you feeling?", "Hello!")
@@ -377,6 +378,7 @@ async def test_assessment_initial_message(
         "next_question": 1,
         "intent": "JOURNEY_RESPONSE",
         "intent_related_response": "",
+        "processed_answer": None,
     }
 
     handle_user_message.assert_not_called()
@@ -458,6 +460,7 @@ async def test_assessment_valid_journey_response(
         "next_question": 2,
         "intent": "JOURNEY_RESPONSE",
         "intent_related_response": "",
+        "processed_answer": "very confident",
     }
 
     # Assert that the core logic functions were called with the correct arguments


### PR DESCRIPTION
Returns the processed_answer back to the journey to save.

We have the question number and assessment name in the journey so we'll save something like:
behaviour-pre-assessment-1: very confident