### PR TITLE
Intent detection pipeline Refactor

### DIFF
--- a/src/ai4gd_momconnect_haystack/evaluation/data/simulation_results_onboarding.json
+++ b/src/ai4gd_momconnect_haystack/evaluation/data/simulation_results_onboarding.json
@@ -4,23 +4,33 @@
     "flow_type": "onboarding",
     "turns": [
       {
-        "question_name": "province",
-        "question_number": null,
-        "llm_utterance": "Which province do you live in?",
-        "user_utterance": "how long will this take?",
-        "follow_up_utterance": "how long will this take?",
-        "user_response": "Skipped - System",
-        "llm_initial_predicted_intent": "JOURNEY_RESPONSE",
-        "llm_final_predicted_intent": "JOURNEY_RESPONSE"
-      },
-      {
         "question_name": "area_type",
         "question_number": null,
-        "llm_utterance": "What kind of area do you live in? For example, city, township, town, farm, village, or rural area.",
+        "llm_utterance": "What kind of area do you live in? For example, city, township, or rural area.",
         "user_utterance": "My baby has a rash, what should I do?",
         "follow_up_utterance": "I live on a farm.",
         "user_response": "Farm or smallholding",
         "llm_initial_predicted_intent": "HEALTH_QUESTION",
+        "llm_final_predicted_intent": "JOURNEY_RESPONSE"
+      },
+      {
+        "question_name": "province",
+        "question_number": null,
+        "llm_utterance": "Which province do you live in?",
+        "user_utterance": "how long will this take?",
+        "follow_up_utterance": "I live on a farm out in the North West.",
+        "user_response": "North West",
+        "llm_initial_predicted_intent": "QUESTION_ABOUT_STUDY",
+        "llm_final_predicted_intent": "JOURNEY_RESPONSE"
+      },
+      {
+        "question_name": "education_level",
+        "question_number": null,
+        "llm_utterance": "What's your highest level of education? For example, did you finish primary or high school?",
+        "user_utterance": "Leave me alone",
+        "follow_up_utterance": "I only finished Grade 9 at school.",
+        "user_response": "Some high school",
+        "llm_initial_predicted_intent": "ASKING_TO_STOP_MESSAGES",
         "llm_final_predicted_intent": "JOURNEY_RESPONSE"
       },
       {
@@ -31,16 +41,6 @@
         "follow_up_utterance": "I am single.",
         "user_response": "Single",
         "llm_initial_predicted_intent": "HEALTH_QUESTION",
-        "llm_final_predicted_intent": "JOURNEY_RESPONSE"
-      },
-      {
-        "question_name": "education_level",
-        "question_number": null,
-        "llm_utterance": "What's your highest level of education? \ud83d\udcda",
-        "user_utterance": "Leave me alone",
-        "follow_up_utterance": "I only finished Grade 9 at school.",
-        "user_response": "Some high school",
-        "llm_initial_predicted_intent": "ASKING_TO_STOP_MESSAGES",
         "llm_final_predicted_intent": "JOURNEY_RESPONSE"
       },
       {
@@ -60,7 +60,7 @@
         "user_utterance": "when wil i get my R5 airtime?",
         "follow_up_utterance": "I have one little one already.",
         "user_response": "1",
-        "llm_initial_predicted_intent": "REPORTING_AIRTIME_NOT_RECEIVED",
+        "llm_initial_predicted_intent": "HEALTH_QUESTION",
         "llm_final_predicted_intent": "JOURNEY_RESPONSE"
       },
       {
@@ -68,9 +68,9 @@
         "question_number": null,
         "llm_utterance": "Do you own the phone you're using right now? \ud83d\udcf1",
         "user_utterance": "ok cool",
-        "follow_up_utterance": "ok cool",
-        "user_response": "Skipped - System",
-        "llm_initial_predicted_intent": "JOURNEY_RESPONSE",
+        "follow_up_utterance": "No, I don't own this phone.",
+        "user_response": "No",
+        "llm_initial_predicted_intent": "CHITCHAT",
         "llm_final_predicted_intent": "JOURNEY_RESPONSE"
       }
     ]

--- a/src/ai4gd_momconnect_haystack/evaluation/data/simulation_results_onboarding.report.txt
+++ b/src/ai4gd_momconnect_haystack/evaluation/data/simulation_results_onboarding.report.txt
@@ -5,14 +5,12 @@
 ==================================================
 
 --- Turn: onboarding_user_123_250616-0635 (onboarding) | ID: province ---
-  Initial Intent: [❌] FAILED
-       Details: Expected: 'QUESTION_ABOUT_STUDY', Got: 'JOURNEY_RESPONSE'
+  Initial Intent: [✅] PASSED
   Follow-up Intent: [✅] PASSED
-  Extraction Accuracy: [❌] FAILED
-       Details: Expected: 'north west', Got: 'skipped - system'
+  Extraction Accuracy: [✅] PASSED
   [ score: 1.00 ] Question Consistency
   [ score: 0.00 ] Response Appropriateness
-       Reason: The score is 0.00 because the output failed to specify a province, which was the main requirement of the input question. Instead, it provided irrelevant details about living on a farm and a directional location, neither of which addressed the question directly.
+       Reason: The score is 0.00 because the output failed to specify a province, which was the core requirement of the input question. Instead, it provided irrelevant information about living on a farm and a general location without addressing the specific query.
 
 --- Turn: onboarding_user_123_250616-0635 (onboarding) | ID: area_type ---
   Initial Intent: [✅] PASSED
@@ -43,18 +41,17 @@
   [ score: 1.00 ] Response Appropriateness
 
 --- Turn: onboarding_user_123_250616-0635 (onboarding) | ID: num_children ---
-  Initial Intent: [✅] PASSED
+  Initial Intent: [❌] FAILED
+       Details: Expected: 'REPORTING_AIRTIME_NOT_RECEIVED', Got: 'HEALTH_QUESTION'
   Follow-up Intent: [✅] PASSED
   Extraction Accuracy: [✅] PASSED
   [ score: 1.00 ] Question Consistency
   [ score: 1.00 ] Response Appropriateness
 
 --- Turn: onboarding_user_123_250616-0635 (onboarding) | ID: phone_ownership ---
-  Initial Intent: [❌] FAILED
-       Details: Expected: 'CHITCHAT', Got: 'JOURNEY_RESPONSE'
+  Initial Intent: [✅] PASSED
   Follow-up Intent: [✅] PASSED
-  Extraction Accuracy: [❌] FAILED
-       Details: Expected: 'no', Got: 'skipped - system'
+  Extraction Accuracy: [✅] PASSED
   [ score: 1.00 ] Question Consistency
   [ score: 1.00 ] Response Appropriateness
 
@@ -68,40 +65,39 @@
 
          ASKING_TO_DELETE_DATA       1.00      1.00      1.00         1
        ASKING_TO_STOP_MESSAGES       1.00      1.00      1.00         1
-                      CHITCHAT       0.00      0.00      0.00         1
-               HEALTH_QUESTION       1.00      1.00      1.00         2
-              JOURNEY_RESPONSE       0.78      1.00      0.88         7
-          QUESTION_ABOUT_STUDY       0.00      0.00      0.00         1
-REPORTING_AIRTIME_NOT_RECEIVED       1.00      1.00      1.00         1
+                      CHITCHAT       1.00      1.00      1.00         1
+               HEALTH_QUESTION       0.67      1.00      0.80         2
+              JOURNEY_RESPONSE       1.00      1.00      1.00         7
+          QUESTION_ABOUT_STUDY       1.00      1.00      1.00         1
+REPORTING_AIRTIME_NOT_RECEIVED       0.00      0.00      0.00         1
 
-                      accuracy                           0.86        14
-                     macro avg       0.68      0.71      0.70        14
-                  weighted avg       0.75      0.86      0.79        14
+                      accuracy                           0.93        14
+                     macro avg       0.81      0.86      0.83        14
+                  weighted avg       0.88      0.93      0.90        14
 
 
 --- Confusion Matrix ---
 shape: (7, 8)
-┌──────────────────┬─────────────────┬─────────────────┬────────────────┬─────────────────┬─────────────────┬─────────────────┬─────────────────┐
-│ Actual           ┆ Pred: ASKING_TO ┆ Pred: ASKING_TO ┆ Pred: CHITCHAT ┆ Pred:           ┆ Pred: JOURNEY_R ┆ Pred: QUESTION_ ┆ Pred: REPORTING │
-│ ---              ┆ _DELETE_DATA    ┆ _STOP_MESSAGES  ┆ ---            ┆ HEALTH_QUESTION ┆ ESPONSE         ┆ ABOUT_STUDY     ┆ _AIRTIME_NOT_RE │
-│ str              ┆ ---             ┆ ---             ┆ i64            ┆ ---             ┆ ---             ┆ ---             ┆ …               │
-│                  ┆ i64             ┆ i64             ┆                ┆ i64             ┆ i64             ┆ i64             ┆ ---             │
-│                  ┆                 ┆                 ┆                ┆                 ┆                 ┆                 ┆ i64             │
-╞══════════════════╪═════════════════╪═════════════════╪════════════════╪═════════════════╪═════════════════╪═════════════════╪═════════════════╡
-│ Actual: ASKING_T ┆ 1               ┆ 0               ┆ 0              ┆ 0               ┆ 0               ┆ 0               ┆ 0               │
-│ O_DELETE_DATA    ┆                 ┆                 ┆                ┆                 ┆                 ┆                 ┆                 │
-│ Actual: ASKING_T ┆ 0               ┆ 1               ┆ 0              ┆ 0               ┆ 0               ┆ 0               ┆ 0               │
-│ O_STOP_MESSAGE…  ┆                 ┆                 ┆                ┆                 ┆                 ┆                 ┆                 │
-│ Actual: CHITCHAT ┆ 0               ┆ 0               ┆ 0              ┆ 0               ┆ 1               ┆ 0               ┆ 0               │
-│ Actual:          ┆ 0               ┆ 0               ┆ 0              ┆ 2               ┆ 0               ┆ 0               ┆ 0               │
-│ HEALTH_QUESTION  ┆                 ┆                 ┆                ┆                 ┆                 ┆                 ┆                 │
-│ Actual:          ┆ 0               ┆ 0               ┆ 0              ┆ 0               ┆ 7               ┆ 0               ┆ 0               │
-│ JOURNEY_RESPONSE ┆                 ┆                 ┆                ┆                 ┆                 ┆                 ┆                 │
-│ Actual: QUESTION ┆ 0               ┆ 0               ┆ 0              ┆ 0               ┆ 1               ┆ 0               ┆ 0               │
-│ _ABOUT_STUDY     ┆                 ┆                 ┆                ┆                 ┆                 ┆                 ┆                 │
-│ Actual: REPORTIN ┆ 0               ┆ 0               ┆ 0              ┆ 0               ┆ 0               ┆ 0               ┆ 1               │
-│ G_AIRTIME_NOT_…  ┆                 ┆                 ┆                ┆                 ┆                 ┆                 ┆                 │
-└──────────────────┴─────────────────┴─────────────────┴────────────────┴─────────────────┴─────────────────┴─────────────────┴─────────────────┘
+┌───────────────────┬───────────────────┬───────────────────┬────────────────┬──────────────────┬──────────────────┬──────────────────┬──────────────────┐
+│ Actual            ┆ Pred: ASKING_TO_D ┆ Pred: ASKING_TO_S ┆ Pred: CHITCHAT ┆ Pred:            ┆ Pred:            ┆ Pred: QUESTION_A ┆ Pred: REPORTING_ │
+│ ---               ┆ ELETE_DATA        ┆ TOP_MESSAGES      ┆ ---            ┆ HEALTH_QUESTION  ┆ JOURNEY_RESPONSE ┆ BOUT_STUDY       ┆ AIRTIME_NOT_RE…  │
+│ str               ┆ ---               ┆ ---               ┆ i64            ┆ ---              ┆ ---              ┆ ---              ┆ ---              │
+│                   ┆ i64               ┆ i64               ┆                ┆ i64              ┆ i64              ┆ i64              ┆ i64              │
+╞═══════════════════╪═══════════════════╪═══════════════════╪════════════════╪══════════════════╪══════════════════╪══════════════════╪══════════════════╡
+│ Actual: ASKING_TO ┆ 1                 ┆ 0                 ┆ 0              ┆ 0                ┆ 0                ┆ 0                ┆ 0                │
+│ _DELETE_DATA      ┆                   ┆                   ┆                ┆                  ┆                  ┆                  ┆                  │
+│ Actual: ASKING_TO ┆ 0                 ┆ 1                 ┆ 0              ┆ 0                ┆ 0                ┆ 0                ┆ 0                │
+│ _STOP_MESSAGE…    ┆                   ┆                   ┆                ┆                  ┆                  ┆                  ┆                  │
+│ Actual: CHITCHAT  ┆ 0                 ┆ 0                 ┆ 1              ┆ 0                ┆ 0                ┆ 0                ┆ 0                │
+│ Actual:           ┆ 0                 ┆ 0                 ┆ 0              ┆ 2                ┆ 0                ┆ 0                ┆ 0                │
+│ HEALTH_QUESTION   ┆                   ┆                   ┆                ┆                  ┆                  ┆                  ┆                  │
+│ Actual:           ┆ 0                 ┆ 0                 ┆ 0              ┆ 0                ┆ 7                ┆ 0                ┆ 0                │
+│ JOURNEY_RESPONSE  ┆                   ┆                   ┆                ┆                  ┆                  ┆                  ┆                  │
+│ Actual: QUESTION_ ┆ 0                 ┆ 0                 ┆ 0              ┆ 0                ┆ 0                ┆ 1                ┆ 0                │
+│ ABOUT_STUDY       ┆                   ┆                   ┆                ┆                  ┆                  ┆                  ┆                  │
+│ Actual: REPORTING ┆ 0                 ┆ 0                 ┆ 0              ┆ 1                ┆ 0                ┆ 0                ┆ 0                │
+│ _AIRTIME_NOT_…    ┆                   ┆                   ┆                ┆                  ┆                  ┆                  ┆                  │
+└───────────────────┴───────────────────┴───────────────────┴────────────────┴──────────────────┴──────────────────┴──────────────────┴──────────────────┘
 ============================================================
 
 
@@ -110,8 +106,8 @@ shape: (7, 8)
 ==================================================
 
 📊 Onboarding Performance (7 turns):
-  - Intent Accuracy: 85.71%
-  - Extraction Accuracy: 71.43%
+  - Intent Accuracy: 92.86%
+  - Extraction Accuracy: 100.00%
   - Avg. Question Consistency: 1.00
   - Avg. Response Appropriateness: 0.86
 
@@ -123,14 +119,12 @@ shape: (7, 8)
 ==================================================
 
 --- Turn: onboarding_user_123_250616-0635 (onboarding) | ID: province ---
-  Initial Intent: [❌] FAILED
-       Details: Expected: 'QUESTION_ABOUT_STUDY', Got: 'JOURNEY_RESPONSE'
+  Initial Intent: [✅] PASSED
   Follow-up Intent: [✅] PASSED
-  Extraction Accuracy: [❌] FAILED
-       Details: Expected: 'north west', Got: 'skipped - system'
+  Extraction Accuracy: [✅] PASSED
   [ score: 1.00 ] Question Consistency
   [ score: 0.00 ] Response Appropriateness
-       Reason: The score is 0.00 because the output failed to specify a province, which was the main requirement of the input question. Instead, it provided irrelevant details about living on a farm and a directional location, neither of which addressed the question directly.
+       Reason: The score is 0.00 because the output failed to specify a province, which was the core requirement of the input question. Instead, it provided irrelevant information about living on a farm and a general location without addressing the specific query.
 
 --- Turn: onboarding_user_123_250616-0635 (onboarding) | ID: area_type ---
   Initial Intent: [✅] PASSED
@@ -161,18 +155,17 @@ shape: (7, 8)
   [ score: 1.00 ] Response Appropriateness
 
 --- Turn: onboarding_user_123_250616-0635 (onboarding) | ID: num_children ---
-  Initial Intent: [✅] PASSED
+  Initial Intent: [❌] FAILED
+       Details: Expected: 'REPORTING_AIRTIME_NOT_RECEIVED', Got: 'HEALTH_QUESTION'
   Follow-up Intent: [✅] PASSED
   Extraction Accuracy: [✅] PASSED
   [ score: 1.00 ] Question Consistency
   [ score: 1.00 ] Response Appropriateness
 
 --- Turn: onboarding_user_123_250616-0635 (onboarding) | ID: phone_ownership ---
-  Initial Intent: [❌] FAILED
-       Details: Expected: 'CHITCHAT', Got: 'JOURNEY_RESPONSE'
+  Initial Intent: [✅] PASSED
   Follow-up Intent: [✅] PASSED
-  Extraction Accuracy: [❌] FAILED
-       Details: Expected: 'no', Got: 'skipped - system'
+  Extraction Accuracy: [✅] PASSED
   [ score: 1.00 ] Question Consistency
   [ score: 1.00 ] Response Appropriateness
 
@@ -186,40 +179,39 @@ shape: (7, 8)
 
          ASKING_TO_DELETE_DATA       1.00      1.00      1.00         1
        ASKING_TO_STOP_MESSAGES       1.00      1.00      1.00         1
-                      CHITCHAT       0.00      0.00      0.00         1
-               HEALTH_QUESTION       1.00      1.00      1.00         2
-              JOURNEY_RESPONSE       0.78      1.00      0.88         7
-          QUESTION_ABOUT_STUDY       0.00      0.00      0.00         1
-REPORTING_AIRTIME_NOT_RECEIVED       1.00      1.00      1.00         1
+                      CHITCHAT       1.00      1.00      1.00         1
+               HEALTH_QUESTION       0.67      1.00      0.80         2
+              JOURNEY_RESPONSE       1.00      1.00      1.00         7
+          QUESTION_ABOUT_STUDY       1.00      1.00      1.00         1
+REPORTING_AIRTIME_NOT_RECEIVED       0.00      0.00      0.00         1
 
-                      accuracy                           0.86        14
-                     macro avg       0.68      0.71      0.70        14
-                  weighted avg       0.75      0.86      0.79        14
+                      accuracy                           0.93        14
+                     macro avg       0.81      0.86      0.83        14
+                  weighted avg       0.88      0.93      0.90        14
 
 
 --- Confusion Matrix ---
 shape: (7, 8)
-┌──────────────────┬─────────────────┬─────────────────┬────────────────┬─────────────────┬─────────────────┬─────────────────┬─────────────────┐
-│ Actual           ┆ Pred: ASKING_TO ┆ Pred: ASKING_TO ┆ Pred: CHITCHAT ┆ Pred:           ┆ Pred: JOURNEY_R ┆ Pred: QUESTION_ ┆ Pred: REPORTING │
-│ ---              ┆ _DELETE_DATA    ┆ _STOP_MESSAGES  ┆ ---            ┆ HEALTH_QUESTION ┆ ESPONSE         ┆ ABOUT_STUDY     ┆ _AIRTIME_NOT_RE │
-│ str              ┆ ---             ┆ ---             ┆ i64            ┆ ---             ┆ ---             ┆ ---             ┆ …               │
-│                  ┆ i64             ┆ i64             ┆                ┆ i64             ┆ i64             ┆ i64             ┆ ---             │
-│                  ┆                 ┆                 ┆                ┆                 ┆                 ┆                 ┆ i64             │
-╞══════════════════╪═════════════════╪═════════════════╪════════════════╪═════════════════╪═════════════════╪═════════════════╪═════════════════╡
-│ Actual: ASKING_T ┆ 1               ┆ 0               ┆ 0              ┆ 0               ┆ 0               ┆ 0               ┆ 0               │
-│ O_DELETE_DATA    ┆                 ┆                 ┆                ┆                 ┆                 ┆                 ┆                 │
-│ Actual: ASKING_T ┆ 0               ┆ 1               ┆ 0              ┆ 0               ┆ 0               ┆ 0               ┆ 0               │
-│ O_STOP_MESSAGE…  ┆                 ┆                 ┆                ┆                 ┆                 ┆                 ┆                 │
-│ Actual: CHITCHAT ┆ 0               ┆ 0               ┆ 0              ┆ 0               ┆ 1               ┆ 0               ┆ 0               │
-│ Actual:          ┆ 0               ┆ 0               ┆ 0              ┆ 2               ┆ 0               ┆ 0               ┆ 0               │
-│ HEALTH_QUESTION  ┆                 ┆                 ┆                ┆                 ┆                 ┆                 ┆                 │
-│ Actual:          ┆ 0               ┆ 0               ┆ 0              ┆ 0               ┆ 7               ┆ 0               ┆ 0               │
-│ JOURNEY_RESPONSE ┆                 ┆                 ┆                ┆                 ┆                 ┆                 ┆                 │
-│ Actual: QUESTION ┆ 0               ┆ 0               ┆ 0              ┆ 0               ┆ 1               ┆ 0               ┆ 0               │
-│ _ABOUT_STUDY     ┆                 ┆                 ┆                ┆                 ┆                 ┆                 ┆                 │
-│ Actual: REPORTIN ┆ 0               ┆ 0               ┆ 0              ┆ 0               ┆ 0               ┆ 0               ┆ 1               │
-│ G_AIRTIME_NOT_…  ┆                 ┆                 ┆                ┆                 ┆                 ┆                 ┆                 │
-└──────────────────┴─────────────────┴─────────────────┴────────────────┴─────────────────┴─────────────────┴─────────────────┴─────────────────┘
+┌───────────────────┬───────────────────┬───────────────────┬────────────────┬──────────────────┬──────────────────┬──────────────────┬──────────────────┐
+│ Actual            ┆ Pred: ASKING_TO_D ┆ Pred: ASKING_TO_S ┆ Pred: CHITCHAT ┆ Pred:            ┆ Pred:            ┆ Pred: QUESTION_A ┆ Pred: REPORTING_ │
+│ ---               ┆ ELETE_DATA        ┆ TOP_MESSAGES      ┆ ---            ┆ HEALTH_QUESTION  ┆ JOURNEY_RESPONSE ┆ BOUT_STUDY       ┆ AIRTIME_NOT_RE…  │
+│ str               ┆ ---               ┆ ---               ┆ i64            ┆ ---              ┆ ---              ┆ ---              ┆ ---              │
+│                   ┆ i64               ┆ i64               ┆                ┆ i64              ┆ i64              ┆ i64              ┆ i64              │
+╞═══════════════════╪═══════════════════╪═══════════════════╪════════════════╪══════════════════╪══════════════════╪══════════════════╪══════════════════╡
+│ Actual: ASKING_TO ┆ 1                 ┆ 0                 ┆ 0              ┆ 0                ┆ 0                ┆ 0                ┆ 0                │
+│ _DELETE_DATA      ┆                   ┆                   ┆                ┆                  ┆                  ┆                  ┆                  │
+│ Actual: ASKING_TO ┆ 0                 ┆ 1                 ┆ 0              ┆ 0                ┆ 0                ┆ 0                ┆ 0                │
+│ _STOP_MESSAGE…    ┆                   ┆                   ┆                ┆                  ┆                  ┆                  ┆                  │
+│ Actual: CHITCHAT  ┆ 0                 ┆ 0                 ┆ 1              ┆ 0                ┆ 0                ┆ 0                ┆ 0                │
+│ Actual:           ┆ 0                 ┆ 0                 ┆ 0              ┆ 2                ┆ 0                ┆ 0                ┆ 0                │
+│ HEALTH_QUESTION   ┆                   ┆                   ┆                ┆                  ┆                  ┆                  ┆                  │
+│ Actual:           ┆ 0                 ┆ 0                 ┆ 0              ┆ 0                ┆ 7                ┆ 0                ┆ 0                │
+│ JOURNEY_RESPONSE  ┆                   ┆                   ┆                ┆                  ┆                  ┆                  ┆                  │
+│ Actual: QUESTION_ ┆ 0                 ┆ 0                 ┆ 0              ┆ 0                ┆ 0                ┆ 1                ┆ 0                │
+│ ABOUT_STUDY       ┆                   ┆                   ┆                ┆                  ┆                  ┆                  ┆                  │
+│ Actual: REPORTING ┆ 0                 ┆ 0                 ┆ 0              ┆ 1                ┆ 0                ┆ 0                ┆ 0                │
+│ _AIRTIME_NOT_…    ┆                   ┆                   ┆                ┆                  ┆                  ┆                  ┆                  │
+└───────────────────┴───────────────────┴───────────────────┴────────────────┴──────────────────┴──────────────────┴──────────────────┴──────────────────┘
 ============================================================
 
 
@@ -228,8 +220,8 @@ shape: (7, 8)
 ==================================================
 
 📊 Onboarding Performance (7 turns):
-  - Intent Accuracy: 85.71%
-  - Extraction Accuracy: 71.43%
+  - Intent Accuracy: 92.86%
+  - Extraction Accuracy: 100.00%
   - Avg. Question Consistency: 1.00
   - Avg. Response Appropriateness: 0.86
 

--- a/src/ai4gd_momconnect_haystack/pipeline_prompts.py
+++ b/src/ai4gd_momconnect_haystack/pipeline_prompts.py
@@ -311,27 +311,86 @@ JSON Response:
     """
 
 INTENT_DETECTION_PROMPT = """
-You are an AI assitant performing intent classification of user responses in a maternal health chatbot.
+You are an expert at classifying user messages within a structured survey conversation. Your task is to analyze the user's response in the context of the last question they were asked and determine their true intent.
+
+First, think step-by-step in a `<reasoning>` block. Analyze if the user is directly answering the question, asking their own question, raising a new concern, or just making a conversational comment.
+
+Second, based on your reasoning, provide the final classification in a `<json>` block.
+
+Here are the possible intents:
+- 'JOURNEY_RESPONSE': The user is directly attempting to answer the question asked.
+- 'QUESTION_ABOUT_STUDY': The user is asking a question about the survey process, why a question is being asked, or who is asking it.
+- 'HEALTH_QUESTION': The user is ignoring the survey question and asking a new, unsolicited question about their health or their baby's health.
+- 'CHITCHAT': The user provides a low-information, conversational filler response that does not answer the question (e.g., "ok", "thanks", "hello").
+- 'ASKING_TO_STOP_MESSAGES': The user explicitly asks to stop receiving messages.
+- 'ASKING_TO_DELETE_DATA': The user explicitly asks to have their data deleted.
+- 'REPORTING_AIRTIME_NOT_RECEIVED': The user is reporting they have not received their airtime incentive.
+
+---
+**Example 1: User asks about the process**
+Last question that was sent to the user: "How confident are you in discussing your maternal health concerns with your healthcare provider?"
+User's response: "how long will this take"
+
+<reasoning>
+The user was asked about their confidence level. Their response, "how long will this take", does not address confidence. It is a meta-question about the duration of the survey itself. This perfectly matches the QUESTION_ABOUT_STUDY intent.
+</reasoning>
+<json>
+{
+    "intent": "QUESTION_ABOUT_STUDY"
+}
+</json>
+
+---
+**Example 2: User gives a simple conversational reply**
+Last question that was sent to the user: "Do you own the phone you're using right now? 📱"
+User's response: "ok cool"
+
+<reasoning>
+The user was asked a "Yes/No" question. Their response, "ok cool," is a conversational acknowledgment but is not an answer. It contains no information related to phone ownership. This is simple chitchat. Therefore, the intent is CHITCHAT.
+</reasoning>
+<json>
+{
+    "intent": "CHITCHAT"
+}
+</json>
+
+---
+**Example 3: User asks an unrelated health question**
+Last question that was sent to the user: "Have you taken your iron supplements today?"
+User's response: "my baby has a bad rash, what can I do?"
+
+<reasoning>
+The user was asked about iron supplements. Their response completely ignores this and asks a new, specific question about a health concern ("a bad rash"). This is a clear example of a HEALTH_QUESTION intent.
+</reasoning>
+<json>
+{
+    "intent": "HEALTH_QUESTION"
+}
+</json>
+
+---
+**Example 4: User gives a direct answer**
+Last question that was sent to the user: "What's your highest level of education? 📚"
+User's response: "I only finished Grade 9 at school."
+
+<reasoning>
+The user was asked about their education. Their response directly answers the question by stating the grade they finished. This is a direct response to the survey question. Therefore, the intent is JOURNEY_RESPONSE.
+</reasoning>
+<json>
+{
+    "intent": "JOURNEY_RESPONSE"
+}
+</json>
+---
+
+**New Task:**
 
 Last question that was sent to the user:
 "{{ last_question }}"
 
 User's response:
 "{{ user_response }}"
-
-Please classify the user's response, in light of the last question sent to the user, into one of these intents:
-- 'JOURNEY_RESPONSE': The user is directly answering, attempting to answer, or skipping the question asked.
-- 'QUESTION_ABOUT_STUDY': The user is asking a question about the research study itself (e.g., "who are you?", "why are you asking this?").
-- 'HEALTH_QUESTION': The user is asking a new question related to health, pregnancy, or their wellbeing, instead of answering the question.
-- 'ASKING_TO_STOP_MESSAGES': The user explicitly expresses a desire to stop receiving messages.
-- 'ASKING_TO_DELETE_DATA': The user explicitly expresses a desire to leave the study and have their data deleted.
-- 'REPORTING_AIRTIME_NOT_RECEIVED': The user is reporting that they have not received their airtime incentive.
-- 'CHITCHAT': The user is making a conversational comment that is not an answer, question or request.
-
-You MUST respond with a valid JSON object containing exactly one key: "intent".
-
-JSON Response:
-    """
+"""
 
 FAQ_PROMPT = """
 You are a helpful assistant for a maternal health chatbot. Answer the user's question based ONLY on the provided context information.


### PR DESCRIPTION
## Refactor: Improve Intent Detection and Pipeline Robustness

This PR addresses inaccuracies in the AI's intent detection capabilities that were identified across all simulation reports ( onboarding, dma, kab, anc-survey). The previous model had a strong bias towards classifying any user input as a direct answer (`JOURNEY_RESPONSE`), failing to correctly identify when a user was asking a question, making small talk, or reporting an issue.



Key Changes and Rationale
1. **Advanced Intent Prompting**
- Why: The primary reason for the inaccuracies was that the INTENT_DETECTION_PROMPT was too simple. It didn't provide enough guidance for the LLM to distinguish between nuanced user inputs across different survey contexts.

- What we did: We implemented a more sophisticated "Chain of Thought" prompt. This new prompt requires the LLM to first write out its reasoning step-by-step before providing a final JSON classification. This forces a more analytical approach and has been shown to significantly improve accuracy on complex classification tasks. The prompt now includes a diverse set of examples that directly target the failure cases identified in the reports.


2. Robust Pipeline Parsing
- Why: The new, advanced prompt produces a more complex output (reasoning text + JSON) that the previous Haystack pipeline could not handle, as the JsonSchemaValidator expected pure JSON. This was causing the pipeline to fail and return no intent.
- What we did: We refactored the intent detection pipeline to make it more robust. We removed the JsonSchemaValidator from the pipeline definition and instead added a "smart parser" directly into the Python code that runs the pipeline (run_intent_detection_pipeline). This new logic uses regular expressions to reliably extract the JSON block from the LLM's 
full response, making the system resilient to formatting variations.