### PR TITLE
conversational repair

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
     "aiosqlite>=0.20.0",
     "polars>=1.31.0",
     "scikit-learn>=1.7.0",
+    "greenlet>=3.0.0",
 ]
 
 [project.scripts]

--- a/src/ai4gd_momconnect_haystack/api.py
+++ b/src/ai4gd_momconnect_haystack/api.py
@@ -54,11 +54,13 @@ from ai4gd_momconnect_haystack.tasks import (
     get_next_onboarding_question,
     handle_user_message,
     handle_intro_response,
+    handle_conversational_repair,
 )
 from ai4gd_momconnect_haystack.utilities import (
     assessment_end_flow_map,
     load_json_and_validate,
     FLOWS_WITH_INTRO,
+    all_onboarding_questions,
 )
 
 from .enums import HistoryType
@@ -156,11 +158,9 @@ async def onboarding(request: OnboardingRequest, token: str = Depends(verify_tok
         user_id=user_id, history_type=HistoryType.onboarding
     )
 
-    previous_context = request.user_context.copy()
-
-    # --- INTRO LOGIC ---
+    # This block handles the very first message of a flow (no user input)
     if not user_input:
-        if flow_id in FLOWS_WITH_INTRO:
+        if flow_id and flow_id in FLOWS_WITH_INTRO:
             await delete_chat_history_for_user(request.user_id, HistoryType.onboarding)
             chat_history = [ChatMessage.from_system(text=SERVICE_PERSONA_TEXT)]
             intro_message = INTRO_MESSAGES["free_text_intro"]
@@ -176,14 +176,35 @@ async def onboarding(request: OnboardingRequest, token: str = Depends(verify_tok
                 intent="SYSTEM_INTRO",
                 intent_related_response=None,
                 results_to_save=[],
+                failure_count=0,
             )
-
+    # This block handles the user's response to the intro message
+    last_assistant_msg = next(
+        (msg for msg in reversed(chat_history) if msg.role.value == "assistant"), None
+    )
     is_intro_response = (
         len(chat_history) == 2 and chat_history[0].role.value == "system"
     )
 
     if is_intro_response:
         result = handle_intro_response(user_input=user_input, flow_id=flow_id)
+        # If user chitchats on intro, trigger repair instead of aborting
+        if result["intent"] == "CHITCHAT":
+            rephrased_question = handle_conversational_repair(
+                flow_id=flow_id,
+                question_identifier=0,  # No specific question number for intro
+                previous_question=last_assistant_msg.text if last_assistant_msg else "",
+                invalid_input=user_input,
+            )
+            return OnboardingResponse(
+                question=rephrased_question
+                or (last_assistant_msg.text if last_assistant_msg else ""),
+                user_context=request.user_context,
+                intent="REPAIR",
+                intent_related_response=None,
+                results_to_save=[],
+                failure_count=request.failure_count + 1,
+            )
 
         response = await _handle_consent_result(
             result=result,
@@ -191,44 +212,105 @@ async def onboarding(request: OnboardingRequest, token: str = Depends(verify_tok
             base_response_args={
                 "user_context": request.user_context,
                 "results_to_save": [],
+                "failure_count": 0,
             },
         )
         if response:
             return response
-
+        # If 'response' is None, it means the user consented and we can proceed.
         chat_history.append(ChatMessage.from_user(text=user_input))
 
     # --- REGULAR ONBOARDING LOGIC ---
     last_question = ""
-    last_assistant_msg = next(
-        (msg for msg in reversed(chat_history) if msg.role.value == "assistant"), None
-    )
     if last_assistant_msg:
         last_question = last_assistant_msg.text
+    last_question_obj = next(
+        (
+            q
+            for q in all_onboarding_questions
+            if q.content and q.content in last_question
+        ),
+        None,
+    )
+    current_question_number = (
+        last_question_obj.question_number if last_question_obj else 0
+    )
 
+    # For subsequent messages, detect intent
     if not is_intro_response:
-        chat_history.append(ChatMessage.from_user(text=user_input))
         intent, intent_related_response = handle_user_message(last_question, user_input)
+        intent = intent or ""
+        intent_related_response = intent_related_response or ""
+
     else:
         intent, intent_related_response = "JOURNEY_RESPONSE", ""
 
-    if intent == "JOURNEY_RESPONSE":
-        user_context, question = process_onboarding_step(
-            user_input=user_input,
-            current_context=request.user_context,
-            current_question=last_question,
+    if intent != "JOURNEY_RESPONSE":
+        if intent == "CHITCHAT":
+            rephrased_question = handle_conversational_repair(
+                flow_id=flow_id,
+                question_identifier=current_question_number,
+                previous_question=last_question,
+                invalid_input=user_input,
+            )
+            return OnboardingResponse(
+                question=rephrased_question or last_question,
+                user_context=request.user_context,
+                intent="REPAIR",
+                intent_related_response=None,
+                results_to_save=[],
+                failure_count=request.failure_count + 1,
+            )
+        return OnboardingResponse(
+            question=last_question,
+            user_context=request.user_context,
+            intent=intent,
+            intent_related_response=intent_related_response,
+            results_to_save=[],
+            failure_count=request.failure_count,
         )
-    else:
-        # If there is no response to the question, the context stays the same
-        user_context = request.user_context
-        question = get_next_onboarding_question(user_context=user_context)
+
+    previous_context = request.user_context.copy()
+    user_context, question = process_onboarding_step(
+        user_input=user_input,
+        current_context=previous_context,
+        current_question=last_question,
+    )
+
+    if not question:  # REPAIR on failed validation
+        if request.failure_count >= 1:  # ESCAPE HATCH
+            logger.warning(
+                f"Onboarding failed for question '{last_question}' twice. Skipping."
+            )
+            # Robust skip logic would go here. For now, we get the next question based on the *unchanged* context.
+            user_context = previous_context  # Revert context
+            question = get_next_onboarding_question(user_context=user_context)
+        else:
+            rephrased_question = handle_conversational_repair(
+                flow_id=flow_id,
+                question_identifier=current_question_number,
+                previous_question=last_question,
+                invalid_input=request.user_input,
+            )
+            return OnboardingResponse(
+                question=rephrased_question or last_question,
+                user_context=previous_context,
+                intent="REPAIR",
+                intent_related_response=None,
+                results_to_save=[],
+                failure_count=request.failure_count + 1,
+            )
 
     question_text = ""
     if question:
         question_text = question.get("contextualized_question", "")
 
+    if not is_intro_response:
+        chat_history.append(ChatMessage.from_user(text=user_input))
+
     if question_text:
         chat_history.append(ChatMessage.from_assistant(text=question_text))
+
     await save_chat_history(
         user_id=request.user_id,
         messages=chat_history,
@@ -236,7 +318,9 @@ async def onboarding(request: OnboardingRequest, token: str = Depends(verify_tok
     )
 
     # Identify what changed in user_context
-    diff_keys = [k for k in user_context if user_context[k] != previous_context.get(k)]
+    diff_keys = [
+        k for k in user_context if user_context.get(k) != previous_context.get(k)
+    ]
 
     return OnboardingResponse(
         question=question_text,
@@ -244,15 +328,17 @@ async def onboarding(request: OnboardingRequest, token: str = Depends(verify_tok
         intent=intent,
         intent_related_response=intent_related_response,
         results_to_save=diff_keys,
+        failure_count=0,
     )
 
 
 @app.post("/v1/assessment")
 async def assessment(request: AssessmentRequest, token: str = Depends(verify_token)):
-    # --- 1. HANDLE START OF A NEW FLOW with INTRO LOGIC ---
+    # --- 1. HANDLE START OF A NEW ASSESSMENT ---
     if not request.user_input:
         await delete_assessment_history_for_user(request.user_id, request.flow_id)
 
+        # Now, check if this specific flow needs an intro message.
         if request.flow_id.value in FLOWS_WITH_INTRO:
             intro_message = (
                 INTRO_MESSAGES["free_text_intro"]
@@ -261,10 +347,11 @@ async def assessment(request: AssessmentRequest, token: str = Depends(verify_tok
             )
             return AssessmentResponse(
                 question=intro_message,
-                next_question=0,  # Use 0 to signal that the next turn is a consent response
+                next_question=0,
                 intent="SYSTEM_INTRO",
                 intent_related_response=None,
                 processed_answer=None,
+                failure_count=0,
             )
 
     # --- 2. HANDLE THE USER'S RESPONSE TO THE INTRO ---
@@ -272,7 +359,6 @@ async def assessment(request: AssessmentRequest, token: str = Depends(verify_tok
         result = handle_intro_response(
             user_input=request.user_input, flow_id=request.flow_id.value
         )
-
         response = await _handle_consent_result(
             result=result,
             response_model=AssessmentResponse,
@@ -280,21 +366,46 @@ async def assessment(request: AssessmentRequest, token: str = Depends(verify_tok
         )
         if response:
             return response
-        # If 'response' is None, it means the user consented and we can proceed.
 
-    processed_answer = None
+    # --- REGULAR TURN LOGIC ---
     current_question_number = (
         1 if request.question_number == 0 else request.question_number
     )
+    next_question_number = current_question_number
+    processed_answer = None
+    intent, intent_related_response = "JOURNEY_RESPONSE", ""
 
-    if request.user_input:
+    if request.user_input and request.question_number != 0:
         intent, intent_related_response = handle_user_message(
             request.previous_question, request.user_input
         )
-    else:
-        intent, intent_related_response = "JOURNEY_RESPONSE", ""
+        intent = intent or ""
 
-    if intent == "JOURNEY_RESPONSE" and request.user_input:
+        if intent != "JOURNEY_RESPONSE":
+            if intent == "CHITCHAT":
+                rephrased_question = handle_conversational_repair(
+                    flow_id=request.flow_id.value,
+                    question_identifier=current_question_number,
+                    previous_question=request.previous_question,
+                    invalid_input=request.user_input,
+                )
+                return AssessmentResponse(
+                    question=rephrased_question or request.previous_question,
+                    next_question=current_question_number,
+                    intent="REPAIR",
+                    intent_related_response=None,
+                    processed_answer=None,
+                    failure_count=request.failure_count + 1,
+                )
+            return AssessmentResponse(
+                question=request.previous_question,
+                next_question=current_question_number,
+                intent=intent,
+                intent_related_response=intent_related_response,
+                processed_answer=None,
+                failure_count=request.failure_count,
+            )
+
         if "behaviour" in request.flow_id.value:
             answer = extract_assessment_data_from_response(
                 user_response=request.user_input,
@@ -308,15 +419,31 @@ async def assessment(request: AssessmentRequest, token: str = Depends(verify_tok
                 current_flow_id=request.flow_id.value,
             )
         processed_answer = answer.get("processed_user_response")
-        next_question_number = answer.get(
-            "next_question_number", current_question_number
-        )
-    elif intent == "SKIP_QUESTION":
-        logger.info(f"User skipped question {request.question_number}. Advancing.")
-        processed_answer = "Skip"
-        next_question_number = request.question_number + 1
-    else:
-        next_question_number = request.question_number
+
+        if not processed_answer:
+            if request.failure_count >= 1:
+                logger.warning(f"Force-skipping question {current_question_number}.")
+                processed_answer = "Skip"
+                next_question_number = current_question_number + 1
+            else:
+                rephrased_question = handle_conversational_repair(
+                    flow_id=request.flow_id.value,
+                    question_identifier=current_question_number,
+                    previous_question=request.previous_question,
+                    invalid_input=request.user_input,
+                )
+                return AssessmentResponse(
+                    question=rephrased_question or request.previous_question,
+                    next_question=current_question_number,
+                    intent="REPAIR",
+                    intent_related_response=None,
+                    processed_answer=None,
+                    failure_count=request.failure_count + 1,
+                )
+        else:
+            next_question_number = answer.get(
+                "next_question_number", current_question_number + 1
+            )
 
     if processed_answer:
         score = score_assessment_question(
@@ -334,6 +461,7 @@ async def assessment(request: AssessmentRequest, token: str = Depends(verify_tok
         )
         await calculate_and_store_assessment_result(request.user_id, request.flow_id)
 
+    # --- FETCH AND RETURN NEXT QUESTION ---
     question = await get_assessment_question(
         user_id=request.user_id,
         flow_id=request.flow_id,
@@ -355,10 +483,11 @@ async def assessment(request: AssessmentRequest, token: str = Depends(verify_tok
 
     return AssessmentResponse(
         question=contextualized_question,
-        next_question=next_question_number,
+        next_question=next_question_number if contextualized_question else None,
         intent=intent,
         intent_related_response=intent_related_response,
         processed_answer=processed_answer,
+        failure_count=0 if processed_answer else request.failure_count,
     )
 
 
@@ -386,7 +515,7 @@ async def assessment_end(
     )
 
     # Determine Current State and Handle User Input
-    task = ""
+    task: str | None = ""
     previous_message_nr = 0
     if messaging_history:
         previous_message_nr = messaging_history[-1].message_number
@@ -493,7 +622,7 @@ async def assessment_end(
 
     return AssessmentEndResponse(
         message=next_message,
-        task=task,
+        task=task or "",
         intent=intent,
         intent_related_response=intent_related_response,
     )
@@ -501,21 +630,16 @@ async def assessment_end(
 
 @app.post("/v1/survey", response_model=SurveyResponse)
 async def survey(request: SurveyRequest, token: str = Depends(verify_token)):
-    """
-    Handles the conversation flow for the ANC (Antenatal Care) survey.
-    It extracts data from the user's response and determines the next question.
-    """
     user_id = request.user_id
     user_input = request.user_input
     flow_id = "anc-survey"
     chat_history = await get_or_create_chat_history(
         user_id=user_id, history_type=request.survey_id
     )
-    previous_context = request.user_context.copy()
 
     # --- INTRO LOGIC ---
     if not user_input:
-        if flow_id in FLOWS_WITH_INTRO:
+        if flow_id and flow_id in FLOWS_WITH_INTRO:
             await delete_chat_history_for_user(request.user_id, HistoryType.anc)
             chat_history = [ChatMessage.from_system(text=SERVICE_PERSONA_TEXT)]
             intro_message = INTRO_MESSAGES["free_text_intro"]
@@ -534,6 +658,7 @@ async def survey(request: SurveyRequest, token: str = Depends(verify_token)):
                 intent="SYSTEM_INTRO",
                 intent_related_response=None,
                 results_to_save=[],
+                failure_count=0,
             )
 
     last_assistant_message = next(
@@ -553,6 +678,7 @@ async def survey(request: SurveyRequest, token: str = Depends(verify_token)):
                 "user_context": request.user_context,
                 "results_to_save": [],
                 "survey_complete": False,
+                "failure_count": 0,
             },
         )
         if response:
@@ -565,47 +691,109 @@ async def survey(request: SurveyRequest, token: str = Depends(verify_token)):
         last_question = last_assistant_message.text
         last_step_title = last_assistant_message.meta.get("step_title", "")
 
+    user_context = request.user_context.copy()
+    previous_context = request.user_context.copy()
+    intent, intent_related_response = "JOURNEY_RESPONSE", ""
+
+    # FIX: Only process input if this is NOT a response to an intro.
     if not is_intro_response:
         chat_history.append(ChatMessage.from_user(text=user_input))
         intent, intent_related_response = handle_user_message(last_question, user_input)
-    else:
-        intent, intent_related_response = "JOURNEY_RESPONSE", ""
+        intent = intent or ""
+        intent_related_response = intent_related_response or ""
 
-    user_context = request.user_context
-    if intent == "JOURNEY_RESPONSE" and not is_intro_response:
+        if intent != "JOURNEY_RESPONSE":
+            if intent == "CHITCHAT":
+                rephrased_question = handle_conversational_repair(
+                    flow_id="anc-survey",
+                    question_identifier=last_step_title,
+                    previous_question=last_question,
+                    invalid_input=request.user_input,
+                )
+                return SurveyResponse(
+                    question=rephrased_question or last_question,
+                    user_context=request.user_context,
+                    survey_complete=False,
+                    intent="REPAIR",
+                    intent_related_response=None,
+                    results_to_save=[],
+                    failure_count=request.failure_count + 1,
+                )
+            return SurveyResponse(
+                question=last_question,
+                user_context=request.user_context,
+                survey_complete=False,
+                intent=intent,
+                intent_related_response=intent_related_response,
+                results_to_save=[],
+                failure_count=request.failure_count,
+            )
+
         user_context = extract_anc_data_from_response(
             user_response=request.user_input,
             user_context=request.user_context,
             step_title=last_step_title,
         )
 
+    if user_context == previous_context and not is_intro_response:
+        if request.failure_count >= 1:
+            logger.warning(
+                f"Survey failed for question '{last_step_title}' twice. Skipping."
+            )
+        else:
+            rephrased_question = handle_conversational_repair(
+                flow_id=flow_id,
+                question_identifier=last_step_title,
+                previous_question=last_question,
+                invalid_input=user_input,
+            )
+            return SurveyResponse(
+                question=rephrased_question or last_question,
+                user_context=previous_context,
+                survey_complete=False,
+                intent="REPAIR",
+                intent_related_response=None,
+                results_to_save=[],
+                failure_count=request.failure_count + 1,
+            )
+
     question_result = await get_anc_survey_question(
-        user_id=user_id, user_context=user_context
+        user_id=request.user_id, user_context=user_context
     )
 
-    question, next_step = "", ""
+    question: str | None = ""
+    next_step = ""
     survey_complete = True
     if question_result:
         question = question_result.get("contextualized_question", "")
         survey_complete = question_result.get("is_final_step", False)
         next_step = question_result.get("question_identifier", "")
 
-    if (not question) and survey_complete:
+    if (not question) and not survey_complete:
+        # If get_anc_survey_question returns None, it's the end of the survey.
+        survey_complete = True
         question = "Thank you for completing the survey!"
 
-    chat_history.append(
-        ChatMessage.from_assistant(text=question, meta={"step_title": next_step})
-    )
+    if question:
+        chat_history.append(
+            ChatMessage.from_assistant(text=question, meta={"step_title": next_step})
+        )
+
     await save_chat_history(
         user_id=request.user_id, messages=chat_history, history_type=request.survey_id
     )
-    diff_keys = [k for k in user_context if user_context[k] != previous_context.get(k)]
+    diff_keys = [
+        k for k in user_context if user_context.get(k) != previous_context.get(k)
+    ]
 
     return SurveyResponse(
-        question=question,
+        question=question or "",
         user_context=user_context,
         survey_complete=survey_complete,
         intent=intent,
         intent_related_response=intent_related_response,
         results_to_save=diff_keys,
+        failure_count=0
+        if user_context != previous_context or request.failure_count >= 1
+        else request.failure_count,
     )

--- a/src/ai4gd_momconnect_haystack/evaluation/evaluator.py
+++ b/src/ai4gd_momconnect_haystack/evaluation/evaluator.py
@@ -114,7 +114,7 @@ class Evaluator:
         except (AttributeError, IndexError):
             return 0.0, "Result extraction failed."
 
-    def run_suite(self):
+    def run_suite(self) -> None:
         """Orchestrates the loading, evaluation, and reporting."""
         print("--- Loading and Collating Evaluation Data ---")
         gt_data = load_json_file(self.gt_path)
@@ -226,12 +226,12 @@ class Evaluator:
             except IOError as e:
                 logging.error(f"Could not write report to file '{output_path}': {e}")
 
-    def _add_line(self, line: str):
+    def _add_line(self, line: str) -> None:
         """Helper to print a line to the console and add it to the report buffer."""
         print(line)
         self.report_lines.append(line)
 
-    def _present_turn_by_turn_report(self):
+    def _present_turn_by_turn_report(self) -> None:
         """Formats and prints the detailed report for each evaluated turn."""
         self._add_line("\n\n" + "=" * 50)
         self._add_line("          DETAILED TURN-BY-TURN REPORT")
@@ -288,7 +288,7 @@ class Evaluator:
                         f"       {Colors.WARNING}Reason: {reason}{Colors.ENDC}"
                     )
 
-    def _present_intent_classification_report(self):
+    def _present_intent_classification_report(self) -> None:
         """Generates and prints a classification report and confusion matrix for intents."""
         y_true, y_pred = [], []
         for res in self.collated_results.values():
@@ -321,7 +321,7 @@ class Evaluator:
         self._add_line(str(cm_df))
         self._add_line("=" * 60)
 
-    def _present_performance_summary_report(self):
+    def _present_performance_summary_report(self) -> None:
         """Aggregates results and prints a high-level performance summary."""
         summary_data: Dict[str, List] = {}
         for (s_id, flow_type, q_name), res in self.collated_results.items():
@@ -379,7 +379,7 @@ class Evaluator:
         self._add_line("\n" + "=" * 50)
 
 
-def main():
+def main() -> None:
     """Parses arguments and orchestrates the evaluation."""
     parser = argparse.ArgumentParser(
         description="Run a multi-faceted evaluation on LLM results."

--- a/src/ai4gd_momconnect_haystack/migrations/env.py
+++ b/src/ai4gd_momconnect_haystack/migrations/env.py
@@ -1,13 +1,13 @@
 from logging.config import fileConfig
 
 from alembic import context
-from sqlalchemy import engine_from_config, pool
+from sqlalchemy import create_engine, pool
 
 from ai4gd_momconnect_haystack.database import DATABASE_URL
 from ai4gd_momconnect_haystack.sqlalchemy_models import Base
 
 config = context.config
-config.set_main_option("sqlalchemy.url", DATABASE_URL)
+# config.set_main_option("sqlalchemy.url", DATABASE_URL)
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
@@ -16,6 +16,7 @@ target_metadata = Base.metadata
 
 
 def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
     url = config.get_main_option("sqlalchemy.url")
     context.configure(
         url=url,
@@ -29,11 +30,8 @@ def run_migrations_offline() -> None:
 
 
 def run_migrations_online() -> None:
-    connectable = engine_from_config(
-        config.get_section(config.config_ini_section, {}),
-        prefix="sqlalchemy.",
-        poolclass=pool.NullPool,
-    )
+    sync_db_url = DATABASE_URL.replace("sqlite+aiosqlite", "sqlite")
+    connectable = create_engine(sync_db_url, poolclass=pool.NullPool)
 
     with connectable.connect() as connection:
         context.configure(connection=connection, target_metadata=target_metadata)

--- a/src/ai4gd_momconnect_haystack/pipeline_prompts.py
+++ b/src/ai4gd_momconnect_haystack/pipeline_prompts.py
@@ -550,3 +550,32 @@ User's Question: {{ user_question }}
 
 Answer:
     """
+
+REPHRASE_QUESTION_PROMPT = """
+You are a patient and empathetic assistant for a maternal health chatbot. The user has just provided an answer that was confusing or did not match the expected options.
+
+Your task is to rephrase the last question to make it simpler and clearer for the user, who may have low literacy.
+
+Here is the context:
+- The last question we asked: "{{ previous_question }}"
+- The user's confusing reply was: "{{ invalid_input }}"
+- The only valid answers we can accept are: {{ valid_responses }}
+
+**Instructions:**
+1.  Start with a short, kind message acknowledging you didn't understand. Examples: "Sorry, I didn't quite get that. Let me ask in a different way:", "My apologies, I'm not sure I understood. Let's try again:", "No problem. To be sure I understand, please can you tell me:"
+2.  Rephrase the core question to be as simple as possible. Remove any complex words or phrasing.
+3.  Clearly list the valid options for the user to choose from.
+4.  Your entire response should be a single, natural-sounding message to the user.
+
+You MUST respond with a valid JSON object containing exactly one key: "rephrased_question".
+
+Example:
+- previous_question: "On a scale of 1 to 5, how much do you agree or disagree with this statement: *I feel like I can make decisions about my health.*"
+- invalid_input: "i think so"
+- valid_responses: ["Strongly disagree", "Disagree", "I’m not sure", "Agree", "Strongly agree"]
+
+JSON Response:
+{
+    "rephrased_question": "Sorry, I didn't quite understand. Please can you tell me how much you agree with this statement: *I feel like I can make decisions about my health.*\\n\\nYou can reply with:\\na. Strongly disagree\\nb. Disagree\\nc. I’m not sure\\nd. Agree\\ne. Strongly agree"
+}
+"""

--- a/src/ai4gd_momconnect_haystack/pydantic_models.py
+++ b/src/ai4gd_momconnect_haystack/pydantic_models.py
@@ -137,6 +137,7 @@ class OnboardingRequest(BaseModel):
     user_id: str
     user_input: str
     user_context: dict[str, Any]
+    failure_count: int = 0
 
 
 class OnboardingResponse(BaseModel):
@@ -145,6 +146,7 @@ class OnboardingResponse(BaseModel):
     intent: str | None
     intent_related_response: str | None
     results_to_save: list[str]
+    failure_count: int
 
 
 class AssessmentRequest(BaseModel):
@@ -154,6 +156,7 @@ class AssessmentRequest(BaseModel):
     flow_id: AssessmentType
     question_number: int
     previous_question: str
+    failure_count: int = 0
 
 
 class AssessmentResponse(BaseModel):
@@ -162,6 +165,7 @@ class AssessmentResponse(BaseModel):
     intent: str | None
     intent_related_response: str | None
     processed_answer: str | None
+    failure_count: int = 0
 
 
 class AssessmentEndRequest(BaseModel):
@@ -172,7 +176,7 @@ class AssessmentEndRequest(BaseModel):
 
 class AssessmentEndResponse(BaseModel):
     message: str
-    task: str
+    task: str | None
     intent: str | None
     intent_related_response: str | None
 
@@ -182,15 +186,17 @@ class SurveyRequest(BaseModel):
     survey_id: HistoryType
     user_input: str
     user_context: dict[str, Any]
+    failure_count: int = 0
 
 
 class SurveyResponse(BaseModel):
-    question: str
+    question: str | None
     user_context: dict[str, Any]
     survey_complete: bool
     intent: str | None
     intent_related_response: str | None
     results_to_save: list[str]
+    failure_count: int = 0
 
 
 class IntroductionMessage(BaseModel):

--- a/src/ai4gd_momconnect_haystack/sqlalchemy_models.py
+++ b/src/ai4gd_momconnect_haystack/sqlalchemy_models.py
@@ -2,7 +2,6 @@ from datetime import datetime
 
 from sqlalchemy import JSON, Boolean, DateTime, Float, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
-from sqlalchemy.sql import func
 
 from .database import Base
 
@@ -20,11 +19,13 @@ class ChatHistory(Base):
         JSON, nullable=False
     )
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
+        DateTime(timezone=True), default=datetime.now
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), onupdate=func.now(), nullable=True
+        DateTime(timezone=True), onupdate=datetime.now, nullable=True
     )
+
+    __table_args__ = {"extend_existing": True}
 
     def __repr__(self):
         return (
@@ -41,12 +42,15 @@ class AssessmentHistory(Base):
     question: Mapped[str] = mapped_column(String, nullable=False)
     user_response: Mapped[str] = mapped_column(String, nullable=True)
     score: Mapped[int] = mapped_column(Integer, nullable=True)
+
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
+        DateTime(timezone=True), default=datetime.now
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), onupdate=func.now(), nullable=True
+        DateTime(timezone=True), onupdate=datetime.now, nullable=True
     )
+
+    __table_args__ = {"extend_existing": True}
 
     def __repr__(self):
         return f"<AssessmentHistory(user_id='{self.user_id}', updated_at='{self.updated_at}')>, question_number='{self.question_number}', score='{self.score}'"
@@ -60,12 +64,15 @@ class AssessmentResultHistory(Base):
     category: Mapped[str] = mapped_column(String, nullable=False)
     score: Mapped[float] = mapped_column(Float, nullable=False)
     crossed_skip_threshold: Mapped[bool] = mapped_column(Boolean, nullable=False)
+
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
+        DateTime(timezone=True), default=datetime.now
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), onupdate=func.now(), nullable=True
+        DateTime(timezone=True), onupdate=datetime.now, nullable=True
     )
+
+    __table_args__ = {"extend_existing": True}
 
     def __repr__(self):
         return f"<AssessmentResultHistory(user_id='{self.user_id}', updated_at='{self.updated_at}', category='{self.category}', crossed_skip_threshold='{self.crossed_skip_threshold}')>"
@@ -78,12 +85,15 @@ class AssessmentEndMessagingHistory(Base):
     assessment_id: Mapped[str] = mapped_column(String, primary_key=True, index=True)
     message_number: Mapped[int] = mapped_column(primary_key=True, index=True)
     user_response: Mapped[str] = mapped_column(String, nullable=True)
+
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
+        DateTime(timezone=True), default=datetime.now
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), onupdate=func.now(), nullable=True
+        DateTime(timezone=True), onupdate=datetime.now, nullable=True
     )
+
+    __table_args__ = {"extend_existing": True}
 
     def __repr__(self):
         return f"<AssessmentEndMessagingHistory(user_id='{self.user_id}', updated_at='{self.updated_at}')>"

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,7 @@ dependencies = [
 dev = [
     { name = "aiosqlite" },
     { name = "deepeval" },
+    { name = "greenlet" },
     { name = "mypy" },
     { name = "polars" },
     { name = "pytest" },
@@ -51,6 +52,7 @@ requires-dist = [
 dev = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "deepeval", specifier = ">=0.24.38" },
+    { name = "greenlet", specifier = ">=3.0.0" },
     { name = "mypy", specifier = ">=1.16.0" },
     { name = "polars", specifier = ">=1.31.0" },
     { name = "pytest", specifier = ">=8.3.5" },


### PR DESCRIPTION
## Title: Refactor API Logic and Add Conversational Repair

This pull request introduces *conversational repair mechanism* across all flows but end-assessment messages (TBA later). It also includes significant refactoring of the API endpoints and data models to improve type safety, correct flawed logic, and resolve numerous bugs uncovered during testing.

Key Changes:

- Feature: Conversational Repair

   - A new handle_conversational_repair task has been added to rephrase questions when a user provides an invalid or confusing response.

   - This mechanism is now integrated into the onboarding, assessment, and survey endpoints, providing a graceful fallback instead of abrupt failures.

   - An "escape hatch" was implemented to automatically skip a question after two consecutive validation failures, preventing users from getting stuck in a repair loop.
  
- Refactor: API Endpoint Logic
   - The onboarding, assessment, and survey endpoints in api.py were substantially refactored to handle different user intents (like CHITCHAT) more cleanly.
   - The logic for handling initial messages, consent, and sequential responses has been clarified and made more robust.
   - Corrected the logic for resetting the failure_count after a successful turn or an automatic skip.
 
- Bug Fixes & Stability:

   - Resolved numerous mypy type errors by updating Pydantic models and variable type hints to correctly handle optional values (str | None).

   - Fixed a critical sqlalchemy.exc.OperationalError in the test environment by making the SQLAlchemy models compatible with both PostgreSQL and SQLite by using datetime.now.

   - Resolved test collection errors (InvalidRequestError) by adding extend_existing=True to SQLAlchemy models.

   - Fixed the Alembic migration environment (env.py) to correctly use a synchronous engine for migrations, resolving all greenlet and async-related errors during test setup.

- Test Suite Improvements:

   - Added greenlet as a development dependency to support the aiosqlite test environment.

   - Corrected multiple flawed test assertions in test_api.py to accurately reflect the intended application behavior, especially around chitchat and history saving.

   - Added a setup_test_database fixture to ensure database migrations are run before the test session, preventing OperationalError: no such table failures.

### Outstanding Issues & Request for Help
After the refactoring, the following `mypy` errors have appeared, and I need assistance to resolve them. The errors indicate that a variable typed as str is being assigned a value that could be str | None.

> `uv run mypy .
src/ai4gd_momconnect_haystack/api.py:379: error: Incompatible types in assignment (expression has type "str | None", variable has type "str")  [assignment]
src/ai4gd_momconnect_haystack/api.py:701: error: Incompatible types in assignment (expression has type "str | None", variable has type "str")  [assignment]
Found 2 errors in 1 file (checked 21 source files)`