### PR TITLE
Summary Screen Bugfix

### DIFF
--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -530,8 +530,8 @@ def test_handle_summary_confirmation_step_with_update(
     result = handle_summary_confirmation_step(user_input, context_copy)
 
     mock_run_pipeline.assert_called_once_with(user_input, context_copy)
-    assert result["intent"] == "ONBOARDING_UPDATE_COMPLETE"
-    assert "Thank you! I've updated your information." in result["question"]
+    assert result["intent"] == "ONBOARDING_COMPLETE_START_DMA"
+    assert "Thank you for the update! Now for the next section." in result["question"]
     assert result["results_to_save"] == ["province"]
 
     updated_context = result["user_context"]
@@ -554,8 +554,8 @@ def test_handle_summary_confirmation_step_with_confirmation(
     result = handle_summary_confirmation_step(user_input, context_copy)
 
     mock_run_pipeline.assert_called_once_with(user_input, context_copy)
-    assert result["intent"] == "ONBOARDING_COMPLETE"
-    assert "Perfect, thank you! Your onboarding is complete." in result["question"]
+    assert result["intent"] == "ONBOARDING_COMPLETE_START_DMA"
+    assert "Perfect, thank you! Now for the next section." in result["question"]
     assert "flow_state" not in result["user_context"]
 
 


### PR DESCRIPTION
### BudFix: Correct Onboarding Consent Flow and DMA Transition

This PR addresses two critical bugs in the onboarding flow that were identified during end-to-end simulation and testing:

1. Repair on Consent: Users who provided a valid consent (e.g., "yes") to the introductory message were incorrectly shown a "conversation repair" prompt.
2.  No Transition to DMA: The flow would end after the new summary screen instead of signaling the start of the DMA assessment.

The changes in this PR resolve these issues by correcting the logical flow in the API and tasks, making the onboarding experience more robust and ensuring the user journey continues as expected.

**Key Changes**

- **Corrected Consent Handling** (api.py): The onboarding endpoint has been updated to cleanly separate the handling of the initial consent response from the first question-and-answer turn. After a user consents, the API now immediately fetches the first question instead of incorrectly re-processing the consent word as a failed answer. Redundant logic has also been removed.

- **Explicit DMA Transition Signal** (`tasks.py`): The handle_summary_confirmation_step task has been updated to consistently return the ONBOARDING_COMPLETE_START_DMA intent upon successful completion of the summary screen (either by confirmation or update). This provides a clear, explicit signal for the calling system to start the next flow.

- **Verification via New Tests** (test_api.py): Two new targeted integration tests have been added to verify both bug fixes:

  - `test_onboarding_consent_proceeds_directly_to_first_question` ensures the consent repair bug is fixed.
  - `test_onboarding_summary_confirmation_signals_start_dma` ensures the DMA transition signal is correctly returned.


- **Updated Existing Tests** (`test_tasks.py`): Assertions in existing tests were updated to align with the new `ONBOARDING_COMPLETE_START_DMA` intent.

------

#### Note for Engineering

**Action Required (on your end): Update to Onboarding API Flow for DMA Transition**

The method for transitioning from the Onboarding flow to the DMA assessment has been updated.

- **Previously**, the calling system had to detect when the question field in the response was an empty string ("") to know when to start the DMA assessment.
- **Now**, the /v1/onboarding endpoint will return a specific intent, ONBOARDING_COMPLETE_START_DMA, in the final OnboardingResponse.

Please update the client-side logic to check for this new intent. When the intent field is ONBOARDING_COMPLETE_START_DMA, the system should immediately initiate the DMA flow by making a new request to the /v1/assessment endpoint.
------
