### PR TITLE
Anc suvery bug fix

### DIFF
--- a/src/ai4gd_momconnect_haystack/api.py
+++ b/src/ai4gd_momconnect_haystack/api.py
@@ -69,6 +69,7 @@ from ai4gd_momconnect_haystack.tasks import (
     handle_reminder_request,
     handle_journey_resumption_prompt,
     handle_intro_reminder,
+    handle_reminder_response,
 )
 from ai4gd_momconnect_haystack.utilities import (
     FLOWS_WITH_INTRO,
@@ -893,6 +894,15 @@ async def survey(request: SurveyRequest, token: str = Depends(verify_token)):
     )
     user_context = request.user_context.copy()
     previous_context = request.user_context.copy()
+
+    # Check if the user's last state was awaiting a response to a reminder
+    saved_state = await get_user_journey_state(user_id)
+    if (
+        saved_state
+        and saved_state.current_step_identifier == "awaiting_reminder_response"
+    ):
+        # If so, hand off to the dedicated reminder response handler
+        return await handle_reminder_response(user_id, user_input, saved_state)
 
     # --- 1. INTRO LOGIC ---
     if not user_input:

--- a/src/ai4gd_momconnect_haystack/pipeline_prompts.py
+++ b/src/ai4gd_momconnect_haystack/pipeline_prompts.py
@@ -630,7 +630,7 @@ You are an expert AI assistant for a maternal health survey. Your task is to ana
 
 **JSON Output Structure:**
 You MUST respond with a valid JSON object with exactly these three keys:
-- `validated_response`: (string) The `standardized_key` you chose from the mapping. If `no_match`, return the user's original, unaltered free-text response.
+- `validated_response`: (string) The `standardized_key` you chose from the mapping. If  `match_type` is `no_match`, return an empty string.
 - `match_type`: (string) One of "exact", "inferred", or "no_match".
 - `confidence`: (string) One of "high" or "low".
 

--- a/src/ai4gd_momconnect_haystack/pipeline_prompts.py
+++ b/src/ai4gd_momconnect_haystack/pipeline_prompts.py
@@ -620,57 +620,33 @@ Use the `extract_updated_data` tool to return all the extracted changes in a sin
 """
 
 SURVEY_DATA_EXTRACTION_PROMPT = """
-You are an expert AI assistant for a maternal health survey. Your task is to analyze a user's free-text response and map it to one of the predefined "valid_responses". You must return a structured JSON object with your analysis.
+You are an expert AI assistant for a maternal health survey. Your task is to analyze a user's free-text response and map it to one of the predefined options based on its meaning.
 
 **Analysis Steps:**
-1.  **Compare**: Compare the user's response against the list of valid responses.
-2.  **Match Type**: Determine the type of match.
-    - `exact`: The user's response is a direct keyword match or a very close synonym (e.g., "yes", "yebo", "yeah" for "Yes").
-    - `inferred`: The user's response does not contain keywords but its meaning can be reasonably inferred to match one of the options.
-    - `no_match`: The user's response is a valid answer to the question but does not align with any of the predefined options.
-3.  **Confidence**: Assess your confidence in the mapping.
-    - `high`: You are certain of the match. This is always the case for an `exact` or `no_match` type.
-    - `low`: The match is a plausible inference but is ambiguous or could be interpreted differently (e.g., user says "Not yet" when an option is "I'm going soon").
-4.  **Validated Response**:
-    - For `exact` or `inferred` matches, this MUST be the exact string of the matched valid response.
-    - For `no_match`, this MUST be the user's original, unaltered free-text response.
+1.  **Analyze**: Understand the user's intent based on their message.
+2.  **Map to Key**: Map the intent to the single most appropriate `standardized_key` from the provided "Response to Key Mapping". The key you return MUST be one of the values from the mapping.
+3.  **Confidence**: Assess your confidence in the mapping (`high` or `low`).
+4.  **Match Type**: Determine the match type (`exact`, `inferred`, `no_match`). If the user's response is a valid answer but does not fit any of the provided options, use `no_match`.
 
 **JSON Output Structure:**
 You MUST respond with a valid JSON object with exactly these three keys:
-- `validated_response`: (string) The matched valid response string, or the user's original text if no match was found.
+- `validated_response`: (string) The `standardized_key` you chose from the mapping. If `no_match`, return the user's original, unaltered free-text response.
 - `match_type`: (string) One of "exact", "inferred", or "no_match".
 - `confidence`: (string) One of "high" or "low".
 
 ---
-**Example 1: Ambiguous Inference (Low Confidence)**
+**Example:**
 - Question: "Did you go to your pregnancy check-up this week?"
-- Valid Responses: ["Yes, I went", "No, I'm not going", "I'm going soon"]
-- User Response: "Not yet"
-- JSON Response:
+- Response to Key Mapping:
 {
-    "validated_response": "I'm going soon",
-    "match_type": "inferred",
-    "confidence": "low"
+    "Yes, I went": "YES",
+    "No, I'm not going": "NO",
+    "I'm going soon": "SOON"
 }
----
-**Example 2 : No Match (Creating an "Other")**
-- Question: "What was the number 1 reason you didn't get to this one?"
-- Valid Responses: ["Transport 🚌", "No support 🤝", "Something else 😞"]
-- User Response: "I was too sick that day"
+- User Response: "I went"
 - JSON Response:
 {
-    "validated_response": "I was too sick that day",
-    "match_type": "no_match",
-    "confidence": "high"
-}
----
-**Example 3: Conversational Affirmative**
-- Question: "We'd love to know how it went. Do you have 2 minutes to tell us about it?"
-- Valid Responses: ["Yes", "Remind me tomorrow"]
-- User Response: "I can"
-- JSON Response:
-{
-    "validated_response": "Yes",
+    "validated_response": "YES",
     "match_type": "inferred",
     "confidence": "high"
 }
@@ -678,7 +654,7 @@ You MUST respond with a valid JSON object with exactly these three keys:
 
 **Your Task:**
 - Previous Question: "{{ previous_service_message }}"
-- Valid Responses: {{ valid_responses }}
+- Response to Key Mapping: {{ response_key_map }}
 - User's Response: "{{ user_response }}"
 
 JSON Response:

--- a/src/ai4gd_momconnect_haystack/pipelines.py
+++ b/src/ai4gd_momconnect_haystack/pipelines.py
@@ -112,126 +112,61 @@ REPHRASED_QUESTION_SCHEMA = {
 ANC_SURVEY_FLOW_LOGIC = {
     "intro": lambda ctx: "start",
     "start": lambda ctx: "Q_seen"
-    if ctx.get("start") == "Yes, I went"
+    if ctx.get("start") == "VISIT_YES"
     else "start_not_going"
-    if ctx.get("start") == "No, I'm not going"
+    if ctx.get("start") == "VISIT_NO"
     else "start_going_soon"
-    if ctx.get("start") == "I'm going soon"
-    else "Q_seen",  # ADDED DEFAULT PATH
-    # I'm going soon
+    if ctx.get("start") == "VISIT_SOON"
+    else "Q_seen",
     "start_going_soon": lambda ctx: "__GOING_SOON_REMINDER_3_DAYS__",
-    # Yes, I went
-    "Q_seen": lambda ctx: "seen_yes"
-    if ctx.get("Q_seen") == "Yes"
-    else "Q_seen_no"
-    if ctx.get("Q_seen") == "No"
-    else "Q_challenges",  # ADDED DEFAULT PATH (skips to a common subsequent question)
+    "Q_seen": lambda ctx: "seen_yes" if ctx.get("Q_seen") == "YES" else "Q_seen_no",
     "seen_yes": lambda ctx: "Q_bp"
-    if ctx.get("seen_yes") == "Yes"
-    else "mom_ANC_remind_me_01"
-    if ctx.get("seen_yes") == "Remind me tomorrow"
-    else "Q_bp",  # ADDED DEFAULT PATH
+    if ctx.get("seen_yes") == "YES"
+    else "mom_ANC_remind_me_01",
     "Q_seen_no": lambda ctx: "Q_why_no_visit"
-    if ctx.get("Q_seen_no") == "Yes"
-    else "mom_ANC_remind_me_01"
-    if ctx.get("Q_seen_no") == "Remind me tomorrow"
-    else "Q_why_no_visit",  # ADDED DEFAULT PATH
-    "Q_why_no_visit": lambda ctx: "intent"
-    if ctx.get("Q_why_no_visit")
-    in [
-        "Clinic was closed ⛔",
-        "Wait time too long ⌛",
-        "No maternity record 📝",
-        "Asked to pay 💰",
-        "Told to come back 📅",
-        "Staff disrespectful 🤬",
-    ]
-    else "Q_why_no_visit_other"
-    if ctx.get("Q_why_no_visit") == "Something else 😞"
-    else "intent",  # ADDED DEFAULT PATH
-    "Q_why_no_visit_other": lambda ctx: "intent",
+    if ctx.get("Q_seen_no") == "YES"
+    else "mom_ANC_remind_me_01",
     "mom_ANC_remind_me_01": lambda ctx: "__NOT_GOING_REMINDER_1_DAY__",
     "Q_bp": lambda ctx: "Q_experience",
     "Q_experience": lambda ctx: "bad"
-    if ctx.get("Q_experience") in ["Bad", "Very bad"]
-    else "good"
-    if ctx.get("Q_experience") in ["Very good", "Good", "OK"]
-    else "Q_visit_good",  # ADDED DEFAULT PATH
+    if ctx.get("Q_experience") in ["EXP_BAD", "EXP_VERY_BAD"]
+    else "good",
     "bad": lambda ctx: "Q_visit_bad",
     "good": lambda ctx: "Q_visit_good",
-    "Q_visit_good": lambda ctx: "Q_challenges"
-    if ctx.get("Q_visit_good")
-    in [
-        "No problems 👌",
-        "No maternity record 📝",
-        "Shamed/embarrassed 😳",
-        "No privacy 🤐",
-        "Not enough info ℹ️",
-        "Staff disespectful 🤬",
-        "Asked to pay 💰",
-        "Waited a long time ⌛",
-    ]
-    else "Q_visit_other"
-    if ctx.get("Q_visit_good") == "Something else 😞"
-    else "Q_challenges",  # ADDED DEFAULT PATH
-    "Q_visit_bad": lambda ctx: "Q_challenges"
-    if ctx.get("Q_visit_bad")
-    in [
-        "No maternity record 📝",
-        "Shamed/embarrassed 😳",
-        "No privacy 🤐",
-        "Not enough info ℹ️",
-        "Staff disrespectful 🤬",
-        "Asked to pay 💰",
-        "Waited a long time ⌛",
-    ]
-    else "Q_visit_other"
-    if ctx.get("Q_visit_bad") == "Something else 😞"
-    else "Q_challenges",  # ADDED DEFAULT PATH
+    "Q_visit_good": lambda ctx: "Q_visit_other"
+    if ctx.get("Q_visit_good") == "SOMETHING_ELSE"
+    else "Q_challenges",
+    "Q_visit_bad": lambda ctx: "Q_visit_other"
+    if ctx.get("Q_visit_bad") == "SOMETHING_ELSE"
+    else "Q_challenges",
     "Q_visit_other": lambda ctx: "Q_challenges",
-    "Q_challenges": lambda ctx: "intent"
-    if ctx.get("Q_challenges")
-    in ["No challenges 👌", "Transport 🚌", "No support 🤝", "Clinic opening hours 🏥"]
-    else "Q_challenges_other"
-    if ctx.get("Q_challenges") == "Something else 😞"
-    else "intent",  # ADDED DEFAULT PATH
+    "Q_challenges": lambda ctx: "Q_challenges_other"
+    if ctx.get("Q_challenges") == "SOMETHING_ELSE"
+    else "intent",
     "Q_challenges_other": lambda ctx: "intent",
-    # No, I'm not going
+    "Q_why_no_visit": lambda ctx: "Q_why_no_visit_other"
+    if ctx.get("Q_why_no_visit") == "SOMETHING_ELSE"
+    else "intent",
+    "Q_why_no_visit_other": lambda ctx: "intent",
     "start_not_going": lambda ctx: "Q_why_not_go"
-    if ctx.get("start_not_going") == "Yes"
-    else "mom_ANC_remind_me_02"
-    if ctx.get("start_not_going") == "Remind me tomorrow"
-    else "Q_why_not_go",  # ADDED DEFAULT PATH
+    if ctx.get("start_not_going") == "YES"
+    else "mom_ANC_remind_me_02",
     "mom_ANC_remind_me_02": lambda ctx: "__WENT_REMINDER_1_DAY__",
-    "Q_why_not_go": lambda ctx: "intent"
-    if ctx.get("Q_why_not_go")
-    in [
-        "Didn't know about it 📅",
-        "Didn't know where 📍",
-        "Don't want check-ups ⛔",
-        "Can't go when open 🏥",
-        "Asked to pay 💰",
-        "Wait times too long ⌛",
-        "No support 🤝",
-        "Getting there is hard 🚌",
-        "I forgot 😧",
-    ]
-    else "Q_why_not_go_other"
-    if ctx.get("Q_why_not_go") == "Something else 😞"
-    else "intent",  # ADDED DEFAULT PATH
+    "Q_why_not_go": lambda ctx: "Q_why_not_go_other"
+    if ctx.get("Q_why_not_go") == "SOMETHING_ELSE"
+    else "intent",
     "Q_why_not_go_other": lambda ctx: "intent",
-    "intent": lambda ctx: "end"
-    if (not ctx.get("first_survey")) and ctx.get("intent") == "Yes, I will"
+    "intent": lambda ctx: "not_going_next_one"
+    if ctx.get("intent") == "WONT_GO"  # Key for "No, I won't"
     else "feedback_if_first_survey"
-    if ctx.get("first_survey") and ctx.get("intent") == "Yes, I will"
-    else "not_going_next_one"
-    if ctx.get("intent") == "No, I won't"
-    else "feedback_if_first_survey",  # ADDED DEFAULT PATH
-    "not_going_next_one": lambda ctx: "end"
-    if not ctx.get("first_survey")
-    else "feedback_if_first_survey",
-    # Feedback and thanks after the user's first survey completion
+    if ctx.get("first_survey")
+    else "end",
+    "not_going_next_one": lambda ctx: "feedback_if_first_survey"
+    if ctx.get("first_survey")
+    else "end",
     "feedback_if_first_survey": lambda ctx: "end_if_feedback",
+    "end_if_feedback": lambda ctx: None,
+    "end": lambda ctx: None,
 }
 
 
@@ -1698,7 +1633,7 @@ def run_rephrase_question_pipeline(
 def run_survey_data_extraction_pipeline(
     user_response: str,
     previous_service_message: str,
-    valid_responses: list[str],
+    response_key_map: dict[str, str],
 ) -> dict | None:
     """
     Runs the confidence-based survey data extraction pipeline.
@@ -1717,7 +1652,7 @@ def run_survey_data_extraction_pipeline(
                     "template_variables": {
                         "user_response": user_response,
                         "previous_service_message": previous_service_message,
-                        "valid_responses": valid_responses,
+                        "response_key_map": response_key_map,
                     },
                 }
             }

--- a/src/ai4gd_momconnect_haystack/static_content/anc_survey.json
+++ b/src/ai4gd_momconnect_haystack/static_content/anc_survey.json
@@ -12,7 +12,7 @@
         },
         {
             "title": "Q_seen",
-            "content": "Did a health worker see you?",
+            "content": "Good to hear. Before we continue, here are a few things to know:\n\nYou can answer *in your own words* — there’s no right or wrong!\nYou can *ask us questions about this study* any time.\nDon’t want to answer something? Just type *skip*.\n\nDid a health worker see you?",
             "content_type": "follow_up_question",
             "valid_responses": [
                 "Yes",
@@ -26,7 +26,7 @@
         },
         {
             "title": "seen_yes",
-            "content": "That's good to hear 🌟\n\nWe'd love to know how it went.  \n\nDo you have 2 minutes to tell us about it?",
+            "content": "That’s good to hear 🌟\n\nWe’d love to know how your check-up went..  \n\nDo you have 2 minutes to tell us about it?",
             "content_type": "follow_up_question",
             "valid_responses": [
                 "Yes",
@@ -57,7 +57,7 @@
         },
         {
             "title": "bad",
-            "content": "We're sorry to hear you had a bad experience.\n\nBy telling us a bit more, you can help us understand how to improve services for pregnant women in South Africa.",
+            "content": "We’re sorry to hear you had a bad experience.\n\nBy telling us a bit more,  you can help us understand how to improve services for pregnant women in South Africa.\n\nReady to tell us?",
             "content_type": "follow_up_question",
             "valid_responses": [
                 "OK"
@@ -65,7 +65,7 @@
         },
         {
             "title": "good",
-            "content": "Thank you for telling us.\n\nThere are just 2 more questions. Your answers to these will help us understand how we can make services better for pregnant women in South Africa.",
+            "content": "Thank you for telling us.\n\nThere are just 2 more questions. Your answers to these will help us understand how we can make services better for pregnant women in South Africa.\n\nReady to go?",
             "content_type": "follow_up_question",
             "valid_responses": [
                 "Continue"
@@ -126,7 +126,7 @@
         },
         {
             "title": "Q_seen_no",
-            "content": "We're sorry to hear that. Do you have time to tell us what happened?",
+            "content": "We’re sorry to hear that. Do you have time to tell us what happened?\n\nDo you have 2 minutes to tell us about it?",
             "content_type": "follow_up_question",
             "valid_responses": [
                 "Yes",

--- a/src/ai4gd_momconnect_haystack/tasks.py
+++ b/src/ai4gd_momconnect_haystack/tasks.py
@@ -16,7 +16,10 @@ from ai4gd_momconnect_haystack.pipelines import (
     run_anc_survey_contextualization_pipeline,
     run_rephrase_question_pipeline,
 )
-from ai4gd_momconnect_haystack.sqlalchemy_models import AssessmentHistory
+from ai4gd_momconnect_haystack.sqlalchemy_models import (
+    AssessmentHistory,
+    UserJourneyState,
+)
 from .pydantic_models import (
     ReengagementInfo,
     OnboardingResponse,
@@ -35,6 +38,7 @@ from .utilities import (
     REMINDER_CONFIG,
     prepare_valid_responses_to_display_to_assessment_user,
     prepare_valid_responses_to_display_to_onboarding_user,
+    create_response_to_key_map,
 )
 
 from fastapi import HTTPException
@@ -503,28 +507,30 @@ def extract_anc_data_from_response(
     step_title: str,
 ) -> tuple[dict, dict | None]:
     """
-    Extracts data from a user's response to an ANC survey question using a
-    confidence-based pipeline.
+    Extracts data from a user's response to an ANC survey question by mapping
+    the response to a standardized key.
     Returns the updated context and an optional action dictionary for the API.
     """
     logger.info("Running confidence-based ANC survey data extraction...")
     question_data = ANC_SURVEY_MAP.get(step_title)
-    action_dict = None  # To hold special instructions for the API
+    action_dict = None
 
     if not question_data:
         logger.error(f"Could not find question content for step_id: '{step_title}'")
         return user_context, None
 
-    # Default to raw user response if there are no predefined options
     if not question_data.valid_responses:
         user_context[step_title] = user_response
         return user_context, None
 
-    # Call our new, more intelligent pipeline
+    # Step 1: Create the mapping from response text to a standardized key
+    response_key_map = create_response_to_key_map(question_data.valid_responses)
+
+    # Step 2: Call the pipeline, passing the key map for the AI to use
     extraction_result = pipelines.run_survey_data_extraction_pipeline(
-        user_response,
-        question_data.content,
-        question_data.valid_responses,
+        user_response=user_response,
+        previous_service_message=question_data.content,
+        response_key_map=response_key_map,  # Pass the map as a keyword argument
     )
 
     if not extraction_result:
@@ -534,49 +540,42 @@ def extract_anc_data_from_response(
     print(f"[Extracted ANC Data]:\n{json.dumps(extraction_result, indent=2)}\n")
 
     match_type = extraction_result.get("match_type")
-    validated_response = extraction_result.get("validated_response")
+    validated_response_key = extraction_result.get("validated_response")
     confidence = extraction_result.get("confidence")
 
-    if confidence == "low":
-        # RECOMMENDATION 1: This is the clarification loop.
-        # Signal the API to ask the user for confirmation.
+    if confidence == "low" and isinstance(
+        validated_response_key, str
+    ):  # FIX: Check key is a string
+        # For the confirmation message, we need the full text, not the key.
+        # We can look it up from our generated map.
+        key_to_response_map = {v: k for k, v in response_key_map.items()}
+        potential_answer_text = key_to_response_map.get(validated_response_key, "")
+
         action_dict = {
             "status": "needs_confirmation",
-            "message": f"It sounds like you meant '{validated_response}'. Is that correct?",
-            "potential_answer": validated_response,
+            "message": f"It sounds like you meant '{potential_answer_text}'. Is that correct?",
+            "potential_answer": validated_response_key,  # We confirm the key
             "step_title_to_confirm": step_title,
         }
         logger.info(
-            f"Low confidence match. Triggering confirmation for: {validated_response}"
+            f"Low confidence match. Triggering confirmation for: {validated_response_key}"
         )
 
     elif match_type == "no_match":
-        # RECOMMENDATION 2: Handle the "Other" category gracefully.
-        other_option = next(
-            (
-                resp
-                for resp in question_data.valid_responses
-                if "Something else" in resp
-            ),
-            None,
-        )
-        if other_option:
-            user_context[step_title] = other_option
-            user_context[f"{step_title}_other_text"] = (
-                validated_response  # Store the verbatim text
-            )
+        other_option_key = response_key_map.get("Something else 😞")
+        if other_option_key:
+            user_context[step_title] = other_option_key
+            user_context[f"{step_title}_other_text"] = validated_response_key
             logger.info(
-                f"Handled as 'other'. Storing '{validated_response}' in '{step_title}_other_text'"
+                f"Handled as 'other'. Storing '{validated_response_key}' in '{step_title}_other_text'"
             )
         else:
-            user_context[step_title] = (
-                validated_response  # Fallback if no "other" option exists
-            )
+            user_context[step_title] = validated_response_key
 
-    elif validated_response:
-        # High-confidence, direct match.
-        user_context[step_title] = validated_response
-        logger.info(f"Updated user_context for {step_title}: {validated_response}")
+    elif validated_response_key:
+        # High-confidence, direct match. Store the KEY in the context.
+        user_context[step_title] = validated_response_key
+        logger.info(f"Updated user_context for {step_title}: {validated_response_key}")
 
     return user_context, action_dict
 
@@ -1114,4 +1113,89 @@ async def handle_intro_reminder(
             processed_answer=None,
             failure_count=0,
             reengagement_info=reengagement_info,
+        )
+
+
+async def handle_reminder_response(
+    user_id: str,
+    user_input: str,
+    state: UserJourneyState,  # The user's saved state
+) -> SurveyResponse:
+    """
+    Processes a user's response to a "Ready to continue?" reminder prompt.
+
+    Returns:
+        A SurveyResponse object with the next question or another reminder.
+    """
+    # Use the robust classifier for the user's "Yes" or "Remind me tomorrow"
+    intent = classify_ussd_intro_response(user_input)
+
+    if intent == "AFFIRMATIVE":
+        # User wants to continue.
+        # We fetch the original question they missed and send it again.
+        restored_context = state.user_context
+        question_to_send = state.last_question_sent
+
+        # If for some reason the last question was empty, get the next logical one
+        if not question_to_send:
+            question_result = await get_anc_survey_question(
+                user_id=user_id, user_context=restored_context
+            )
+            if question_result:
+                question_to_send = question_result.get("contextualized_question", "")
+
+        return SurveyResponse(
+            question=question_to_send,
+            user_context=restored_context,
+            survey_complete=False,
+            intent="JOURNEY_RESUMED",
+            intent_related_response=None,
+            results_to_save=[],
+            failure_count=0,
+        )
+
+    elif intent == "REMIND_LATER":
+        # User wants another reminder. Schedule it.
+        # This re-uses the existing reminder logic for DRYness.
+        message, reengagement_info = await handle_reminder_request(
+            user_id=user_id,
+            flow_id=state.current_flow_id,
+            step_identifier=state.current_step_identifier,
+            last_question=state.last_question_sent,
+            user_context=state.user_context,
+            reminder_type=2,  # This is at least the second reminder
+        )
+        return SurveyResponse(
+            question=message,
+            user_context=state.user_context,
+            survey_complete=False,
+            intent="REQUEST_TO_BE_REMINDED",
+            intent_related_response=None,
+            results_to_save=[],
+            failure_count=0,
+            reengagement_info=reengagement_info,
+        )
+
+    else:  # Ambiguous response
+        # Re-send the reminder prompt to clarify
+        # FIX: Correctly determine the schedule key to get the right resume message
+        schedule_key = "default"
+        if "survey" in state.current_flow_id:
+            schedule_key = "survey"
+        elif "onboarding" in state.current_flow_id:
+            schedule_key = "onboarding"
+        elif "behaviour" in state.current_flow_id:
+            schedule_key = "kab"
+
+        schedule = REMINDER_CONFIG.get(schedule_key, REMINDER_CONFIG["default"])
+        rephrased_question = schedule[0].get("resume_message")
+
+        return SurveyResponse(
+            question=rephrased_question,
+            user_context=state.user_context,
+            survey_complete=False,
+            intent="REPAIR",
+            intent_related_response=None,
+            results_to_save=[],
+            failure_count=0,
         )

--- a/src/ai4gd_momconnect_haystack/tasks.py
+++ b/src/ai4gd_momconnect_haystack/tasks.py
@@ -39,6 +39,7 @@ from .utilities import (
     prepare_valid_responses_to_display_to_assessment_user,
     prepare_valid_responses_to_display_to_onboarding_user,
     create_response_to_key_map,
+    prepare_valid_responses_to_display_to_anc_survey_user,
 )
 
 from fastapi import HTTPException
@@ -492,7 +493,12 @@ async def get_anc_survey_question(user_id: str, user_context: dict) -> dict | No
         valid_responses,
     )
 
-    final_question_text = text_to_prepend + contextualized_question
+    final_question_text = prepare_valid_responses_to_display_to_anc_survey_user(
+        text_to_prepend=text_to_prepend,
+        question=contextualized_question,
+        valid_responses=valid_responses or [],
+        step_title=next_step,
+    )
 
     return {
         "contextualized_question": final_question_text.strip(),

--- a/src/ai4gd_momconnect_haystack/tasks.py
+++ b/src/ai4gd_momconnect_haystack/tasks.py
@@ -568,15 +568,17 @@ def extract_anc_data_from_response(
         )
 
     elif match_type == "no_match":
-        other_option_key = response_key_map.get("Something else 😞")
-        if other_option_key:
-            user_context[step_title] = other_option_key
-            user_context[f"{step_title}_other_text"] = validated_response_key
-            logger.info(
-                f"Handled as 'other'. Storing '{validated_response_key}' in '{step_title}_other_text'"
-            )
-        else:
-            user_context[step_title] = validated_response_key
+        # Find the standardized key for the "Something else" option.
+        other_option_key = next(
+            (v for k, v in response_key_map.items() if "Something else" in k), "OTHER"
+        )
+
+        user_context[step_title] = other_option_key
+        # Save the user's raw, unaltered text in a separate field.
+        user_context[f"{step_title}_other_text"] = user_response
+        logger.info(
+            f"Handled as 'other'. Storing '{user_response}' in '{step_title}_other_text'"
+        )
 
     elif validated_response_key:
         # High-confidence, direct match. Store the KEY in the context.

--- a/src/ai4gd_momconnect_haystack/utilities.py
+++ b/src/ai4gd_momconnect_haystack/utilities.py
@@ -484,7 +484,7 @@ def create_response_to_key_map(valid_responses: list[str]) -> dict[str, str]:
     """
     key_map = {}
     for response in valid_responses:
-        # Create a key by taking the first few words, making them uppercase,
+        # Create a key by taking the first two words, making them uppercase,
         # and joining with underscores. This is a robust way to generate unique keys.
         words = re.sub(r"[^\w\s]", "", response).split()[:2]
         key = "_".join(words).upper()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -12,12 +12,17 @@ from ai4gd_momconnect_haystack.assessment_logic import (
     validate_assessment_answer,
 )
 from ai4gd_momconnect_haystack.enums import AssessmentType
+from ai4gd_momconnect_haystack.utilities import create_response_to_key_map
+from ai4gd_momconnect_haystack.sqlalchemy_models import UserJourneyState
 from ai4gd_momconnect_haystack.pydantic_models import (
     AssessmentQuestion,
     AssessmentRun,
     ResponseScore,
     Turn,
+    SurveyResponse,
+    ReengagementInfo,
 )
+
 from ai4gd_momconnect_haystack.tasks import (
     extract_onboarding_data_from_response,
     get_assessment_question,
@@ -30,6 +35,7 @@ from ai4gd_momconnect_haystack.tasks import (
     classify_yes_no_response,
     handle_reminder_request,
     classify_ussd_intro_response,
+    handle_reminder_response,
 )
 
 # --- Test Data Fixtures ---
@@ -494,7 +500,7 @@ def test_extract_anc_data_no_match_handles_other(mock_run_pipeline):
         user_response="I was too sick", user_context={}, step_title="Q_challenges"
     )
 
-    assert context["Q_challenges"] == "Something else 😞"
+    assert context["Q_challenges"] == "SOMETHING_ELSE"
     assert context["Q_challenges_other_text"] == "I was too sick"
     assert action_dict is None
 
@@ -801,3 +807,109 @@ def test_classify_ussd_intro_response(user_input, expected_classification):
     with a variety of user input formats.
     """
     assert classify_ussd_intro_response(user_input) == expected_classification
+
+
+def test_create_response_to_key_map_generates_correct_keys():
+    """
+    Tests that the helper function correctly generates a map of response text to standardized keys.
+    """
+
+    valid_responses = [
+        "Yes, I went",
+        "No, I'm not going",
+        "Something else 😞",
+        "Very good",
+    ]
+
+    expected_map = {
+        "Yes, I went": "YES",
+        "No, I'm not going": "NO",
+        "Something else 😞": "SOMETHING_ELSE",
+        "Very good": "EXP_VERY_GOOD",
+    }
+
+    key_map = create_response_to_key_map(valid_responses)
+    assert key_map == expected_map
+
+
+@pytest.mark.asyncio
+async def test_handle_reminder_response_affirmative():
+    """
+    Tests that when a user affirmatively responds to a reminder, the original question is returned.
+    """
+    mock_state = UserJourneyState(
+        user_id="test-user",
+        current_flow_id="anc-survey",
+        current_step_identifier="start",
+        last_question_sent="This was the original question.",
+        user_context={},
+    )
+
+    response = await handle_reminder_response(
+        user_id="test-user", user_input="a. Yes", state=mock_state
+    )
+
+    assert isinstance(response, SurveyResponse)
+    assert response.question == "This was the original question."
+    assert response.intent == "JOURNEY_RESUMED"
+
+
+@pytest.mark.asyncio
+@mock.patch(
+    "ai4gd_momconnect_haystack.tasks.handle_reminder_request",
+    new_callable=mock.AsyncMock,
+)
+async def test_handle_reminder_response_remind_later(mock_reminder_request):
+    """
+    Tests that when a user asks for another reminder, the request is handled correctly.
+    """
+    # FIX: Return a real ReengagementInfo object, not a generic mock
+    reengagement_info = ReengagementInfo(
+        type="USER_REQUESTED",
+        trigger_at_utc=datetime.now(timezone.utc),
+        flow_id="anc-survey",
+        reminder_type=2,
+    )
+    mock_reminder_request.return_value = (
+        "OK, we'll remind you again.",
+        reengagement_info,
+    )
+
+    mock_state = UserJourneyState(
+        user_id="test-user",
+        current_flow_id="anc-survey",
+        current_step_identifier="start",
+        last_question_sent="Original question.",
+        user_context={"reminder_count": 1},
+    )
+
+    response = await handle_reminder_response(
+        user_id="test-user", user_input="b. Remind me tomorrow", state=mock_state
+    )
+
+    mock_reminder_request.assert_awaited_once()
+    assert response.intent == "REQUEST_TO_BE_REMINDED"
+    assert response.question == "OK, we'll remind you again."
+    assert response.reengagement_info == reengagement_info
+
+
+@pytest.mark.asyncio
+async def test_handle_reminder_response_ambiguous():
+    """
+    Tests that an ambiguous response to a reminder re-sends the reminder prompt.
+    """
+    mock_state = UserJourneyState(
+        user_id="test-user",
+        current_flow_id="anc-survey",
+        current_step_identifier="start",
+        last_question_sent="Original question.",
+        user_context={},
+    )
+
+    response = await handle_reminder_response(
+        user_id="test-user", user_input="maybe later", state=mock_state
+    )
+
+    assert response.intent == "REPAIR"
+    assert "Hello 👋🏽" in response.question
+    assert "You started telling us about" in response.question

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -915,6 +915,7 @@ async def test_handle_reminder_response_ambiguous():
     assert "Hello 👋🏽" in response.question
     assert "You started telling us about" in response.question
 
+
 @pytest.mark.asyncio
 @mock.patch("ai4gd_momconnect_haystack.tasks.run_anc_survey_contextualization_pipeline")
 @mock.patch("ai4gd_momconnect_haystack.tasks.get_next_anc_survey_step")


### PR DESCRIPTION
**Fix: Resolve ANC Survey Bugs and Implement Re-engagement**

This PR addresses several critical bugs in the ANC Survey reported by QA. The primary issue was the survey's brittle conversational flow, which relied on exact-string matching and had incomplete logic paths, leading to unpredictable behaviour and premature termination of the survey.

Additionally, this PR completes the backend implementation for the re-engagement feature, aligning it with the Figma design specifications.

Key changes made:

- Refactored ANC Survey Logic: The entire survey flow was refactored to use a robust, key-based system instead of fragile text matching. This involved updating the AI prompt (`pipeline_prompts.py`), the data extraction task (`tasks.py`), and the core flow logic (`pipelines.py`).
- Completed Conversation Flow: `The ANC_SURVEY_FLOW_LOGIC` was corrected to include previously missing steps, ensuring the survey can run from start to finish without breaking.
- Implemented Re-engagement Backend: Added the handle_reminder_response task and the necessary API routing in `api.py` to correctly handle the user conversation during a re-engagement sequence.

- Fixed Content and Formatting:

   - Updated the static survey content in `anc_survey.json` to include missing introductory messages and align with the designs.
   - Corrected the logic in `tasks.py` to ensure multiple-choice options are properly displayed to the user.
   - Updated the `REMINDER_CONFIG` in `utilities.py` to use the correct resume message and reminder delay.


**Testing**

- Added a comprehensive suite of new unit and API-level integration tests to validate the refactored logic and the new re-engagement feature.
- Updated existing tests to align with the new changes.


Related Issues:
Resolves: [[QA Bug Ticket](https://praekelt.leankit.com/card/31512283122941)]