### PR TITLE
Bugfix(tasks): Prevent crash on re-engagement from reminder prompt

### DIFF
--- a/src/ai4gd_momconnect_haystack/tasks.py
+++ b/src/ai4gd_momconnect_haystack/tasks.py
@@ -1039,7 +1039,6 @@ async def handle_journey_resumption_prompt(
             user_context=state.user_context,
         )
 
-        # --- THIS IS THE FIX ---
         # Use separate, explicit blocks for each response type
         if "onboarding" in state.current_flow_id:
             return OnboardingResponse(
@@ -1051,9 +1050,16 @@ async def handle_journey_resumption_prompt(
                 failure_count=0,
             )
         else:  # Default to AssessmentResponse for KAB flows
+            # Check if the step identifier is a digit before converting to int.
+            # If not (e.g., it's 'awaiting_reminder_response'), we can't determine a
+            # specific next question number, so we default to None.
+            next_q_num = None
+            if state.current_step_identifier.isdigit():
+                next_q_num = int(state.current_step_identifier)
+
             return AssessmentResponse(
                 question=resume_message,
-                next_question=int(state.current_step_identifier),
+                next_question=next_q_num,
                 intent="SYSTEM_REMINDER_PROMPT",
                 intent_related_response=None,
                 processed_answer=None,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2051,3 +2051,58 @@ async def test_api_anc_survey_full_turn_with_key_refactor(
     mock_get_question.assert_awaited_once_with(
         user_id="test-user", user_context=updated_context_with_key
     )
+
+
+@pytest.mark.asyncio
+@mock.patch.dict(os.environ, {"API_TOKEN": "testtoken"}, clear=True)
+async def test_resumption_from_awaiting_reminder_state_is_safe(client: TestClient):
+    """
+    BUG FIX VERIFICATION:
+    Tests that if a user drops out *after* receiving a resume prompt,
+    the system can safely re-engage them a second time without crashing.
+    This specifically targets the `int('awaiting_reminder_response')` ValueError.
+    """
+    user_id = "double-dropout-user"
+
+    # Arrange: Manually create the problematic state in the database.
+    # The user was on step 5 of an assessment, got re-engaged once, and we are
+    # now about to re-engage them a second time.
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            session.add(
+                UserJourneyState(
+                    user_id=user_id,
+                    current_flow_id="dma-pre-assessment",
+                    # This is the state that caused the crash
+                    current_step_identifier="awaiting_reminder_response",
+                    last_question_sent="Hi! Ready to pick up where you left off...?",
+                    user_context={"reminder_count": 1},
+                )
+            )
+            await session.commit()
+
+    # Act: The platform re-engages the user a second time.
+    response = client.post(
+        "/v1/assessment",  # Calling the assessment endpoint to resume
+        headers={"Authorization": "Token testtoken"},
+        json={
+            "user_id": user_id,
+            "user_input": "",
+            "user_context": {"resume": True},
+            "flow_id": "dma-pre-assessment",  # This is needed for the assessment endpoint
+            "question_number": 0,  # Not relevant here, but required by the model
+            "previous_question": "",  # Not relevant here, but required by the model
+        },
+    )
+
+    # Assert:
+    # 1. The API call must succeed and not crash.
+    assert response.status_code == 200
+    json_response = response.json()
+
+    # 2. The user should receive the resume prompt again.
+    assert "Hi! Ready to pick up" in json_response["question"]
+
+    # 3. CRITICAL: The `next_question` field must be None, because the step
+    #    identifier was not a number. This proves the fix is working.
+    assert json_response["next_question"] is None


### PR DESCRIPTION
**Description**
This PR fixes a critical bug where the application would crash with a ValueError if a user was re-engaged for a second time after dropping out of an assessment flow.

**Root Cause:**
If a user received a "Ready to continue?" prompt and then went silent again, their state was saved with a step identifier of "awaiting_reminder_response". On the next re-engagement, the logic that builds the AssessmentResponse tried to convert this string to an integer, causing a fatal crash.

**Solution:**
The `handle_journey_resumption_prompt` helper function in `tasks.py` has been updated to be more robust. It now checks if the `current_step_identifier` is a digit before attempting to convert it to an integer. If it's not a digit (e.g., "awaiting_reminder_response"), it safely defaults to `None`, preventing the crash and ensuring a smooth user experience.