### PR TITLE
Anc suvery bug fix

### DIFF
--- a/src/ai4gd_momconnect_haystack/api.py
+++ b/src/ai4gd_momconnect_haystack/api.py
@@ -68,6 +68,7 @@ from ai4gd_momconnect_haystack.tasks import (
     handle_journey_resumption_prompt,
     handle_intro_reminder,
     handle_reminder_response,
+    classify_yes_no_response,
 )
 from ai4gd_momconnect_haystack.utilities import (
     FLOWS_WITH_INTRO,
@@ -1052,90 +1053,101 @@ async def survey(request: SurveyRequest, token: str = Depends(verify_token)):
             else ""
         )
 
-        last_question_data = ANC_SURVEY_MAP.get(last_step_title)
-        valid_responses_for_intent = (
-            last_question_data.valid_responses if last_question_data else []
-        )
-        intent, intent_related_response = handle_user_message(
-            last_question, user_input, valid_responses_for_intent
-        )
-
-        if intent == "SKIP_QUESTION":
-            user_context[last_step_title] = "Skip"
-        elif intent == "JOURNEY_RESPONSE":
-            user_context, action_dict = extract_anc_data_from_response(
-                user_response=user_input,
-                user_context=user_context,
-                step_title=last_step_title,
-                contextualized_question=last_question,
+        # For the critical 'intent' question, use the reliable classifier.
+        if last_step_title == "intent":
+            classification = classify_yes_no_response(user_input)
+            # Treat AMBIGUOUS as NEGATIVE to be cautious
+            user_context["intent"] = "YES" if classification == "AFFIRMATIVE" else "NO"
+            logger.info(
+                f"For step 'intent', classified response as '{classification}' -> '{user_context['intent']}'"
+            )
+        # For all other questions, use the original AI-based logic.
+        else:
+            last_question_data = ANC_SURVEY_MAP.get(last_step_title)
+            valid_responses_for_intent = (
+                last_question_data.valid_responses if last_question_data else []
+            )
+            intent, intent_related_response = handle_user_message(
+                last_question, user_input, valid_responses_for_intent
             )
 
-            if action_dict and action_dict.get("status") == "needs_confirmation":
-                user_context["pending_confirmation"] = action_dict
-                confirmation_question = action_dict["message"]
-                chat_history.append(
-                    ChatMessage.from_assistant(
-                        text=confirmation_question, meta={"step_title": "confirmation"}
-                    )
+            if intent == "SKIP_QUESTION":
+                user_context[last_step_title] = "Skip"
+            elif intent == "JOURNEY_RESPONSE":
+                user_context, action_dict = extract_anc_data_from_response(
+                    user_response=user_input,
+                    user_context=user_context,
+                    step_title=last_step_title,
+                    contextualized_question=last_question,
                 )
-                await save_chat_history(
+
+                if action_dict and action_dict.get("status") == "needs_confirmation":
+                    user_context["pending_confirmation"] = action_dict
+                    confirmation_question = action_dict["message"]
+                    chat_history.append(
+                        ChatMessage.from_assistant(
+                            text=confirmation_question,
+                            meta={"step_title": "confirmation"},
+                        )
+                    )
+                    await save_chat_history(
+                        user_id=user_id,
+                        messages=chat_history,
+                        history_type=request.survey_id,
+                    )
+                    return SurveyResponse(
+                        question=confirmation_question,
+                        question_identifier="confirmation",
+                        user_context=user_context,
+                        survey_complete=False,
+                        intent="SYSTEM_CONFIRM",
+                        intent_related_response=None,
+                        results_to_save=[],
+                        failure_count=request.failure_count,
+                    )
+            elif intent == "REQUEST_TO_BE_REMINDED":
+                state = await get_user_journey_state(user_id)
+                current_reminder_count = state.reminder_count if state else 0
+                new_reminder_count = current_reminder_count + 1
+                reminder_type = 2 if new_reminder_count >= 2 else 1
+                user_context["reminder_count"] = new_reminder_count
+
+                message, reengagement_info = await handle_reminder_request(
                     user_id=user_id,
-                    messages=chat_history,
-                    history_type=request.survey_id,
+                    flow_id=flow_id,
+                    step_identifier=last_step_title,
+                    last_question=last_question,
+                    user_context=user_context,
+                    reminder_type=reminder_type,
                 )
                 return SurveyResponse(
-                    question=confirmation_question,
-                    question_identifier="confirmation",
+                    question=message,
+                    question_identifier=last_step_title,
                     user_context=user_context,
                     survey_complete=False,
-                    intent="SYSTEM_CONFIRM",
+                    intent=intent,
                     intent_related_response=None,
                     results_to_save=[],
-                    failure_count=request.failure_count,
+                    failure_count=0,
+                    reengagement_info=reengagement_info,
                 )
-        elif intent == "REQUEST_TO_BE_REMINDED":
-            state = await get_user_journey_state(user_id)
-            current_reminder_count = state.reminder_count if state else 0
-            new_reminder_count = current_reminder_count + 1
-            reminder_type = 2 if new_reminder_count >= 2 else 1
-            user_context["reminder_count"] = new_reminder_count
-
-            message, reengagement_info = await handle_reminder_request(
-                user_id=user_id,
-                flow_id=flow_id,
-                step_identifier=last_step_title,
-                last_question=last_question,
-                user_context=user_context,
-                reminder_type=reminder_type,
-            )
-            return SurveyResponse(
-                question=message,
-                question_identifier=last_step_title,
-                user_context=user_context,
-                survey_complete=False,
-                intent=intent,
-                intent_related_response=None,
-                results_to_save=[],
-                failure_count=0,
-                reengagement_info=reengagement_info,
-            )
-        else:  # Handle chitchat or other non-journey intents
-            rephrased_question = handle_conversational_repair(
-                flow_id=flow_id,
-                question_identifier=last_step_title,
-                previous_question=last_question,
-                invalid_input=user_input,
-            )
-            return SurveyResponse(
-                question=rephrased_question,
-                question_identifier=last_step_title,
-                user_context=user_context,
-                survey_complete=False,
-                intent="REPAIR",
-                intent_related_response=None,
-                results_to_save=[],
-                failure_count=request.failure_count + 1,
-            )
+            else:  # Handle chitchat or other non-journey intents
+                rephrased_question = handle_conversational_repair(
+                    flow_id=flow_id,
+                    question_identifier=last_step_title,
+                    previous_question=last_question,
+                    invalid_input=user_input,
+                )
+                return SurveyResponse(
+                    question=rephrased_question,
+                    question_identifier=last_step_title,
+                    user_context=user_context,
+                    survey_complete=False,
+                    intent="REPAIR",
+                    intent_related_response=None,
+                    results_to_save=[],
+                    failure_count=request.failure_count + 1,
+                )
 
         if user_context == previous_context:
             if request.failure_count >= 1:

--- a/src/ai4gd_momconnect_haystack/doc_store.py
+++ b/src/ai4gd_momconnect_haystack/doc_store.py
@@ -430,11 +430,11 @@ def setup_document_store(startup: bool = False) -> WeaviateDocumentStore:
     # If the document store is empty, ingest the content
     if startup or initial_doc_count == 0:
         logger.info("Document store is empty. Proceeding with ingestion.")
-        # if initial_doc_count > 0:
-        #    all_docs = document_store.filter_documents()
-        #    doc_ids = [doc.id for doc in all_docs]
-        #    document_store.delete_documents(doc_ids)
-        #    logger.info(f"Deleted {len(doc_ids)} old documents.")
+        if initial_doc_count > 0:
+            all_docs = document_store.filter_documents()
+            doc_ids = [doc.id for doc in all_docs]
+            document_store.delete_documents(doc_ids)
+            logger.info(f"Deleted {len(doc_ids)} old documents.")
         indexing_pipe = create_embedding_pipeline(document_store)
         logger.info("--- Ingesting Onboarding Content ---")
         ingest_onboarding_content(indexing_pipe, ONBOARDING_FLOW, "onboarding")

--- a/src/ai4gd_momconnect_haystack/enums.py
+++ b/src/ai4gd_momconnect_haystack/enums.py
@@ -18,5 +18,5 @@ class HistoryType(str, Enum):
 
 
 class ReminderType(IntEnum):
-    FIRST = 1
-    SECOND = 2
+    USER_REQUESTED = 1
+    SYSTEM_SCHEDULED_THREE_DAY = 2

--- a/src/ai4gd_momconnect_haystack/main.py
+++ b/src/ai4gd_momconnect_haystack/main.py
@@ -1731,7 +1731,10 @@ async def run_simulation(gt_scenarios: list[dict[str, Any]] | None = None):
                     anc_user_context[question_identifier] = "Skip"
                 elif final_predicted_intent == "JOURNEY_RESPONSE":
                     anc_user_context, action_dict = extract_anc_data_from_response(
-                        final_user_response, anc_user_context, question_identifier
+                        final_user_response,
+                        anc_user_context,
+                        question_identifier,
+                        contextualized_question,
                     )
 
                     if (

--- a/src/ai4gd_momconnect_haystack/pipeline_prompts.py
+++ b/src/ai4gd_momconnect_haystack/pipeline_prompts.py
@@ -623,7 +623,7 @@ SURVEY_DATA_EXTRACTION_PROMPT = """
 You are an expert AI assistant for a maternal health survey. Your task is to analyze a user's free-text response and map it to one of the predefined options based on its meaning.
 
 **Analysis Steps:**
-1.  **Analyze**: Understand the user's intent based on their message.
+1.  **Analyze**: Understand the user's core intent. Pay close attention to **positive or neutral statements** (e.g., "everything was fine," "it went smoothly," "no problems") which should map to a "No problems" or similar option if one exists.
 2.  **Map to Key**: Map the intent to the single most appropriate `standardized_key` from the provided "Response to Key Mapping". The key you return MUST be one of the values from the mapping.
 3.  **Confidence**: Assess your confidence in the mapping (`high` or `low`).
 4.  **Match Type**: Determine the match type (`exact`, `inferred`, `no_match`). If the user's response is a valid answer but does not fit any of the provided options, use `no_match`.
@@ -635,7 +635,7 @@ You MUST respond with a valid JSON object with exactly these three keys:
 - `confidence`: (string) One of "high" or "low".
 
 ---
-**Example:**
+**Example 1:**
 - Question: "Did you go to your pregnancy check-up this week?"
 - Response to Key Mapping:
 {
@@ -647,6 +647,21 @@ You MUST respond with a valid JSON object with exactly these three keys:
 - JSON Response:
 {
     "validated_response": "YES",
+    "match_type": "inferred",
+    "confidence": "high"
+}
+---
+**Example 2 (Handling Positive Sentiment):**
+- Question: "If there was anything you found difficult, tell us what made you the most uncomfortable..."
+- Response to Key Mapping:
+{
+    "No problems 👌": "NO_PROBLEMS",
+    "Something else 😞": "SOMETHING_ELSE"
+}
+- User Response: "it was all fine"
+- JSON Response:
+{
+    "validated_response": "NO_PROBLEMS",
     "match_type": "inferred",
     "confidence": "high"
 }

--- a/src/ai4gd_momconnect_haystack/pipelines.py
+++ b/src/ai4gd_momconnect_haystack/pipelines.py
@@ -157,7 +157,7 @@ ANC_SURVEY_FLOW_LOGIC = {
     else "intent",
     "Q_why_not_go_other": lambda ctx: "intent",
     "intent": lambda ctx: "not_going_next_one"
-    if ctx.get("intent") == "WONT_GO"  # Key for "No, I won't"
+    if ctx.get("intent") == "NO"
     else "feedback_if_first_survey"
     if ctx.get("first_survey")
     else "end",

--- a/src/ai4gd_momconnect_haystack/pipelines.py
+++ b/src/ai4gd_momconnect_haystack/pipelines.py
@@ -112,11 +112,11 @@ REPHRASED_QUESTION_SCHEMA = {
 ANC_SURVEY_FLOW_LOGIC = {
     "intro": lambda ctx: "start",
     "start": lambda ctx: "Q_seen"
-    if ctx.get("start") == "VISIT_YES"
+    if ctx.get("start") == "YES"
     else "start_not_going"
-    if ctx.get("start") == "VISIT_NO"
+    if ctx.get("start") == "NO"
     else "start_going_soon"
-    if ctx.get("start") == "VISIT_SOON"
+    if ctx.get("start") == "IM_GOING"
     else "Q_seen",
     "start_going_soon": lambda ctx: "__GOING_SOON_REMINDER_3_DAYS__",
     "Q_seen": lambda ctx: "seen_yes" if ctx.get("Q_seen") == "YES" else "Q_seen_no",

--- a/src/ai4gd_momconnect_haystack/pydantic_models.py
+++ b/src/ai4gd_momconnect_haystack/pydantic_models.py
@@ -202,6 +202,7 @@ class SurveyRequest(BaseModel):
 
 class SurveyResponse(BaseModel):
     question: str | None
+    question_identifier: str | None = None
     user_context: dict[str, Any]
     survey_complete: bool
     intent: str | None

--- a/src/ai4gd_momconnect_haystack/static_content/anc_survey.json
+++ b/src/ai4gd_momconnect_haystack/static_content/anc_survey.json
@@ -22,7 +22,7 @@
         {
             "title": "start_going_soon",
             "content": "OK, that's great! We'll check in a few days to see how it went 💕",
-            "content_type": "follow_up_question"
+            "content_type": "follow_up_message"
         },
         {
             "title": "seen_yes",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1216,7 +1216,10 @@ async def test_repair_on_intro_consent(mock_handle_intro, mock_get_q):
 )
 @mock.patch(
     "ai4gd_momconnect_haystack.api.extract_anc_data_from_response",
-    side_effect=lambda user_response, user_context, step_title: (user_context, None),
+    side_effect=lambda user_response,
+    user_context,
+    step_title,
+    contextualized_question: (user_context, None),
 )
 @mock.patch(
     "ai4gd_momconnect_haystack.api.process_onboarding_step", return_value=({}, None)
@@ -1314,7 +1317,10 @@ async def test_flow_repair_on_invalid_answer(
 @mock.patch("ai4gd_momconnect_haystack.api.handle_conversational_repair")
 @mock.patch(
     "ai4gd_momconnect_haystack.api.extract_anc_data_from_response",
-    side_effect=lambda user_response, user_context, step_title: (user_context, None),
+    side_effect=lambda user_response,
+    user_context,
+    step_title,
+    contextualized_question: (user_context, None),
 )
 @mock.patch(
     "ai4gd_momconnect_haystack.api.process_onboarding_step", return_value=({}, None)


### PR DESCRIPTION
### Refactor Reminder System and ANC Survey Logic

In this PR we, addresses several critical bugs and logical flaws within the ANC survey flow that were causing loops and unnatural conversations.  We also refactor the **reminder** and **re-engagement** system to make it more flexible and powerful.  The goal is to significantly improve the reliability, maintainability, and user experience of the chatbot.

**Key Changes**

- **ANC Survey Bug Fixes & Logic Improvements 🐛**

   - Special Handling for intent Step: The survey endpoint in api.py now uses the deterministic classify_yes_no_response function for the critical intent question, bypassing the unreliable AI extractor for this step. This guarantees that "no" or neutral answers are handled correctly. 

   - `no_match` Loop Fix: The `extract_anc_data_from_response` function in `tasks.py` has been refactored to prioritise checking for no_match before low_confidence, which resolves the infinite loop bug. 

   - Improved AI Prompt: The `SURVEY_DATA_EXTRACTION_PROMPT` has been enhanced with clearer instructions and a new example for handling positive sentiment, making the AI more accurate when it is used. 

   - Flow Logic Correction: The keys in `ANC_SURVEY_FLOW_LOGIC` were updated (e.g., `VISIT_YES` to `YES`) to match the keys generated by the data extraction process. 

- **Reminder Refactor ⚙️**

   - The `REMINDER_CONFIG` in `utilities.py` has been completely refactored from a simple list into a more structured dictionary.  This allows for more complex, named reminder types (e.g., `DEFAULT`, `FOLLOW_UP`) instead of relying on sequence order.

   - The `ReminderType` enum was updated to be more descriptive (`USER_REQUESTED`, `SYSTEM_SCHEDULED_THREE_DAY`), reflecting the new capabilities. 

   - All related functions in `tasks.py` (`handle_reminder_request`, `handle_journey_resumption_prompt`, etc.) have been updated to use this new, more robust configuration. 


- **New Feature: Proactive 3-Day Reminder ✨**

   - If a user responds that they are "going soon" to their check-up, the system now automatically schedules a proactive reminder to check in with them in 3 days. 
