### PR TITLE
Qa survey reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ The API is documented in this readme, but there is also automatically generated 
 ### Authentication
 Authentication is handled through the `Authorization` HTTP header, the value of which should be `Token <token>`. The token is configured using the `API_TOKEN` environment variable. There is only one token for the whole service.
 
+## QA Reset Feature
+- **How it Works:** An admin must first add a QA tester's user ID to the `QA_USER_IDS` environment variable (`QA_USER_IDS="27821112222,27833334444"`). The authorized tester can then send the !reset command at any time during any conversation flow (onboarding, survey, etc.) to trigger the reset.
+
+- **What it Does:** The command permanently deletes all records for that user from five key tables: `ChatHistory`, `AssessmentHistory`, `AssessmentResultHistory`, `AssessmentEndMessagingHistory`, and `UserJourneyState`.
+
+- **Outcome:** This allows the tester to immediately restart any flow from the beginning as if they were a new user.
+
 ### Intents
 For every response, we first classify the intent of the user's message. If the intent is to answer the qusetion that we asked them, then we should continue as normal. But if it's not, then we should take a different action depending on the intent. There are `intent` and `intent_related_response` fields added to every response to deal with this. The values for `intent` are:
 

--- a/src/ai4gd_momconnect_haystack/crud.py
+++ b/src/ai4gd_momconnect_haystack/crud.py
@@ -456,3 +456,34 @@ async def get_user_journey_state(user_id: str) -> UserJourneyState | None:
             select(UserJourneyState).where(UserJourneyState.user_id == user_id)
         )
         return result.scalar_one_or_none()
+
+
+async def reset_user_state(user_id: str) -> None:
+    """
+    Deletes all chat history, assessment history, results, and journey state for a user.
+    """
+    logger.info(f"Resetting all state for user_id: {user_id}")
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            # Delete all records associated with the user_id from all relevant tables
+            await session.execute(
+                delete(ChatHistory).where(ChatHistory.user_id == user_id)
+            )
+            await session.execute(
+                delete(AssessmentHistory).where(AssessmentHistory.user_id == user_id)
+            )
+            await session.execute(
+                delete(AssessmentResultHistory).where(
+                    AssessmentResultHistory.user_id == user_id
+                )
+            )
+            await session.execute(
+                delete(AssessmentEndMessagingHistory).where(
+                    AssessmentEndMessagingHistory.user_id == user_id
+                )
+            )
+            await session.execute(
+                delete(UserJourneyState).where(UserJourneyState.user_id == user_id)
+            )
+
+    logger.info(f"Successfully reset state for user_id: {user_id}")


### PR DESCRIPTION
## Feat: Add QA User Reset Command
This PR introduces a `!reset` command to allow authorised QA testers to easily reset their user state directly from within WhatsApp. This solves the problem of testers being unable to retake a survey after completing it, removing the need for manual database intervention and streamlining the testing process. The logic is placed in the catchall endpoint to ensure the command is globally available from any point in the conversation.

**Key Changes:**
- Adds !reset Command Handler: The `/v1/catchall` endpoint now checks for the !reset command.
- Security: The feature is secured using a new `QA_USER_IDS` environment variable (e.g. `QA_USER_IDS="27821112222,27833334444"`). The command will only work for users whose IDs are on this list.
- Data Deletion: A reset_user_state function has been added to `crud.py` to completely wipe a user's records from all relevant history tables.
- Testing: Comprehensive tests have been added to verify the success path for QA users, the security path for regular users, and the full end-to-end user journey.


**How to Tes:t**
- Add your test `userID` to the QA_USER_IDS environment variable.
- Go through a flow that only allows to do it once (e.g. Survey).
- Once completed survey, send the message !reset.
- Verify you receive the confirmation message and can restart the survey from the beginning.