### PR TITLE
Reset ANC after completion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,7 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "haystack_integrations.*"
 ignore_missing_imports = true
+
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/src/ai4gd_momconnect_haystack/main.py
+++ b/src/ai4gd_momconnect_haystack/main.py
@@ -1620,7 +1620,9 @@ async def run_simulation(gt_scenarios: list[dict[str, Any]] | None = None):
 
                 print("-" * 20)
                 result = await get_anc_survey_question(
-                    user_id=user_id, user_context=anc_user_context
+                    user_id=user_id,
+                    user_context=anc_user_context,
+                    chat_history=chat_history,
                 )
 
                 if not result:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2121,14 +2121,28 @@ async def test_resumption_from_awaiting_reminder_state_is_safe(client: TestClien
 @pytest.mark.parametrize(
     "scenario, user_id, mock_state, expected_state_calls",
     [
-        ( "COMPLETED_SURVEY", "completed_user", 
-          UserJourneyState(current_flow_id="anc-survey", current_step_identifier=""), 1),
+        (
+            "COMPLETED_SURVEY",
+            "completed_user",
+            UserJourneyState(current_flow_id="anc-survey", current_step_identifier=""),
+            1,
+        ),
         # For the NO_STATE case, we now correctly expect 2 calls
-        ( "NO_STATE", "new_user", None, 2),
-        ( "DIFFERENT_FLOW", "onboarding_user", 
-          UserJourneyState(current_flow_id="onboarding", current_step_identifier="step_2"), 1),
+        ("NO_STATE", "new_user", None, 2),
+        (
+            "DIFFERENT_FLOW",
+            "onboarding_user",
+            UserJourneyState(
+                current_flow_id="onboarding", current_step_identifier="step_2"
+            ),
+            1,
+        ),
     ],
-    ids=["When survey is completed", "When no state exists", "When state is for another flow"],
+    ids=[
+        "When survey is completed",
+        "When no state exists",
+        "When state is for another flow",
+    ],
 )
 @patch("ai4gd_momconnect_haystack.api.save_user_journey_state", new_callable=AsyncMock)
 @patch("ai4gd_momconnect_haystack.api.get_anc_survey_question")
@@ -2156,7 +2170,7 @@ async def test_survey_resume_is_bypassed_for_non_resumable_states(
         "question_identifier": "start",
         "is_final_step": False,
     }
-    
+
     request = SurveyRequest(
         user_id=user_id,
         survey_id=HistoryType.anc,
@@ -2170,10 +2184,11 @@ async def test_survey_resume_is_bypassed_for_non_resumable_states(
     # --- Assert ---
     # This assertion is now flexible and checks for the correct call count in each case
     assert mock_get_state.call_count == expected_state_calls
-    
+
     mock_handle_resume.assert_not_called()
     mock_get_question.assert_called_once()
     assert response.question == "Welcome! Here is the first question."
+
 
 @patch("ai4gd_momconnect_haystack.api.save_user_journey_state", new_callable=AsyncMock)
 @patch("ai4gd_momconnect_haystack.api.get_anc_survey_question")

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -947,7 +947,9 @@ async def test_get_anc_survey_question_appends_ussd_options(
     mock_get_history.return_value = []
 
     # Act
-    result = await get_anc_survey_question(user_id="test-user", user_context={}, chat_history=[])
+    result = await get_anc_survey_question(
+        user_id="test-user", user_context={}, chat_history=[]
+    )
 
     # Assert
     assert result is not None
@@ -986,7 +988,9 @@ async def test_get_anc_survey_question_sets_3_day_reminder(
     expected_trigger_time = fake_now + timedelta(days=3)
 
     # 2. Act: Call the function we want to test
-    result = await get_anc_survey_question(user_id="test-user", user_context={}, chat_history=[])
+    result = await get_anc_survey_question(
+        user_id="test-user", user_context={}, chat_history=[]
+    )
 
     # 3. Assert: Check that the result is correct
     assert result is not None

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -947,7 +947,7 @@ async def test_get_anc_survey_question_appends_ussd_options(
     mock_get_history.return_value = []
 
     # Act
-    result = await get_anc_survey_question(user_id="test-user", user_context={})
+    result = await get_anc_survey_question(user_id="test-user", user_context={}, chat_history=[])
 
     # Assert
     assert result is not None
@@ -986,7 +986,7 @@ async def test_get_anc_survey_question_sets_3_day_reminder(
     expected_trigger_time = fake_now + timedelta(days=3)
 
     # 2. Act: Call the function we want to test
-    result = await get_anc_survey_question(user_id="test-user", user_context={})
+    result = await get_anc_survey_question(user_id="test-user", user_context={}, chat_history=[])
 
     # 3. Assert: Check that the result is correct
     assert result is not None


### PR DESCRIPTION
This PR fixes a bug where users who completed a survey would get stuck in a resume loop. Our previous attempt at solving this by clearing DB (#58), is not effective as any response from a once invokes a re-engagement.  As such this, solution aims to go to the core of the problem. 

We also addresses cascading test failures by refactoring the survey logic to prevent redundant database calls. Key changes include updating function signatures to pass chat_history and making test assertions more precise to reflect the corrected application behaviour.


