### PR TITLE
Expanded affirmative mapping on YesOrNo questions

### DIFF
--- a/src/ai4gd_momconnect_haystack/tasks.py
+++ b/src/ai4gd_momconnect_haystack/tasks.py
@@ -947,8 +947,8 @@ def classify_yes_no_response(user_input: str) -> str:
     """
     user_input_lower = user_input.lower().strip()
     # Using word boundaries (\b) for more accurate matching
-    affirmative_pattern = r"\b(yes|yebo|y|ok|okay|sure|please|definitely|course)\b"
-    negative_pattern = r"\b(no|nope|n|stop|not|nah|never)\b"
+    affirmative_pattern = r"\b(yes|yebo|y|ok|okay|sure|please|definitely|course|yup|yep|yeah|ja|yah|yea|ewe)\b"
+    negative_pattern = r"\b(no|nope|n|stop|not|nah|never|nee|hayi)\b"
 
     is_affirmative = bool(re.search(affirmative_pattern, user_input_lower))
     is_negative = bool(re.search(negative_pattern, user_input_lower))


### PR DESCRIPTION
This PR expands the yes/no intent classifier to recognise common and South African variations like "yup" and "nee". This fixes a bug where users' responses were misunderstood, improving the conversational robustness.