### PR TITLE
BugFix: USSD repair messge stacking

### DIFF
--- a/src/ai4gd_momconnect_haystack/tasks.py
+++ b/src/ai4gd_momconnect_haystack/tasks.py
@@ -812,10 +812,17 @@ def handle_conversational_repair(
         logger.info(
             f"Using template-based repair for USSD-style question: {flow_id} - {question_identifier}"
         )
-        ack = "Sorry, we don’t understand your answer! Please try again.\n\n"
+        # Define the components of the repair message
+        ack = "Sorry, we don't understand your answer! Please try again.\n\n"
         instruction = "\n\nPlease reply with the letter corresponding to your answer."
-        # The `previous_question` already contains the formatted a,b,c options
-        return ack + previous_question + instruction
+
+        # Clean any previous repair message components from the incoming question text
+        cleaned_question = (
+            previous_question.replace(ack, "").replace(instruction, "").strip()
+        )
+
+        # Rebuild the message correctly to prevent stacking
+        return ack + cleaned_question + instruction
     else:
         # For free-text questions, use the LLM to rephrase
         logger.info(


### PR DESCRIPTION
This PR fixes a bug where the conversational repair message was stacking on repeated invalid answers in USSD-style flows. The `handle_conversational_repair` function now cleans the previous question text to ensure the apology and instructions appear only once.