### PR TITLE
Save and use expected_step_id for survey reengagement

### DIFF
--- a/src/ai4gd_momconnect_haystack/crud.py
+++ b/src/ai4gd_momconnect_haystack/crud.py
@@ -408,6 +408,7 @@ def save_user_journey_state(
     user_context: dict[str, Any],
     reminder_type: int | None = None,
     next_question_number: int | None = None,
+    expected_step_id: str | None = None,
 ):
     """
     Creates or updates the user's last known state in the database.
@@ -436,6 +437,8 @@ def save_user_journey_state(
                 existing_state.reminder_type = reminder_type
                 if next_question_number:
                     existing_state.next_question_number = next_question_number
+                if expected_step_id:
+                    existing_state.expected_step_id = expected_step_id
                 logger.info(f"Updated journey state for user {user_id}.")
             else:
                 # Create new record
@@ -449,6 +452,8 @@ def save_user_journey_state(
                 )
                 if next_question_number:
                     new_state.next_question_number = next_question_number
+                if expected_step_id:
+                    new_state.expected_step_id = expected_step_id
                 session.add(new_state)
                 logger.info(f"Created new journey state for user {user_id}.")
             session.commit()

--- a/src/ai4gd_momconnect_haystack/survey_orchestrator.py
+++ b/src/ai4gd_momconnect_haystack/survey_orchestrator.py
@@ -321,6 +321,7 @@ def _finalise_and_respond(
         step_identifier=next_step_id,
         last_question=assistant_message,
         user_context=ctx.current_context,
+        expected_step_id=next_step_id,
     )
     crud.save_chat_history(
         ctx.request.user_id, ctx.history, HistoryType(ctx.request.survey_id)

--- a/src/ai4gd_momconnect_haystack/tasks.py
+++ b/src/ai4gd_momconnect_haystack/tasks.py
@@ -1322,9 +1322,8 @@ def handle_reminder_response(
                 if next_q_result:
                     question_to_send = next_q_result.get("contextualized_question", "")
 
-        delete_user_journey_state(user_id)
-
         if "onboarding" in state.current_flow_id:
+            delete_user_journey_state(user_id)
             return OnboardingResponse(
                 question=question_to_send,
                 user_context=restored_context,
@@ -1334,6 +1333,14 @@ def handle_reminder_response(
                 failure_count=0,
             )
         elif "survey" in state.current_flow_id:
+            save_user_journey_state(
+                user_id=user_id,
+                flow_id=state.current_flow_id,
+                step_identifier=state.expected_step_id,
+                last_question=question_to_send,
+                user_context=restored_context,
+                expected_step_id=state.expected_step_id,
+            )
             return SurveyResponse(
                 question=question_to_send,
                 user_context=restored_context,
@@ -1349,6 +1356,7 @@ def handle_reminder_response(
             #     if state.current_step_identifier.isdigit()
             #     else int(restored_context.get("next_question_number", 0))
             # )
+            delete_user_journey_state(user_id)
             next_q_num = state.next_question_number or 0
             return AssessmentResponse(
                 question=question_to_send,


### PR DESCRIPTION
`step_identifier` gets used for `awaiting_reminder_response` so we use `expected_step_id` to save current step.

The new survey code expects it on the user journey state