### PR TITLE
Fix migration messing with logging config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN uv sync --all-extras
 
 COPY . .
 
-CMD ["uv", "run", "uvicorn", "ai4gd_momconnect_haystack.api:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uv", "run", "uvicorn", "ai4gd_momconnect_haystack.api:app", "--host", "0.0.0.0", "--port", "8000", "--log-config", "log_conf.yaml"]

--- a/log_conf.yaml
+++ b/log_conf.yaml
@@ -1,0 +1,15 @@
+version: 1
+disable_existing_loggers: False
+formatters:
+  default:
+    format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+handlers:
+  default:
+    formatter: default
+    class: logging.StreamHandler
+    stream: ext://sys.stderr
+root:
+  level: INFO
+  handlers:
+    - default
+  propagate: no

--- a/src/ai4gd_momconnect_haystack/migrations/env.py
+++ b/src/ai4gd_momconnect_haystack/migrations/env.py
@@ -1,5 +1,3 @@
-from logging.config import fileConfig
-
 from alembic import context
 from sqlalchemy import create_engine, pool
 
@@ -9,8 +7,6 @@ from ai4gd_momconnect_haystack.sqlalchemy_models import Base
 config = context.config
 # config.set_main_option("sqlalchemy.url", DATABASE_URL)
 
-if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
 
 target_metadata = Base.metadata
 


### PR DESCRIPTION
This PR does two things to fix the logging issue:
1. Removes the logging config overrride from alembic. Turns out this was a file in our repo that we control, so once I found that it was easy enough to remove
2. Move the logging config to uvicorn for the API. If we do this in our app, uvicorn starts up first and applies its logging, and then we're trying to override things. Much easier to just pass a logging config to uvicorn from the beginning, and have it apply to everything. This means that we supply the logging config as a file, and pass the file path to the uvicorn command
