### PR TITLE
Fix POST KAB assessment end KeyError issue

### DIFF
--- a/src/ai4gd_momconnect_haystack/utilities.py
+++ b/src/ai4gd_momconnect_haystack/utilities.py
@@ -1,10 +1,10 @@
-from datetime import datetime, timedelta
-import re
 import json
 import logging
+import re
+from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any
 from string import ascii_lowercase
+from typing import Any
 
 from haystack.dataclasses import ChatMessage
 from pydantic import BaseModel, ValidationError
@@ -12,7 +12,6 @@ from pydantic import BaseModel, ValidationError
 from ai4gd_momconnect_haystack import doc_store
 from ai4gd_momconnect_haystack.enums import AssessmentType
 from ai4gd_momconnect_haystack.pydantic_models import AssessmentQuestion
-
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +66,10 @@ assessment_end_flow_map = {
     kab_k_pre_flow_id: kab_k_end_messaging_pre,
     kab_a_pre_flow_id: kab_a_end_messaging_pre,
     kab_b_pre_flow_id: kab_b_end_messaging_pre,
+    # PRE and POST end assessments are the same
+    kab_k_post_flow_id: kab_k_end_messaging_pre,
+    kab_a_post_flow_id: kab_a_end_messaging_pre,
+    kab_b_post_flow_id: kab_b_end_messaging_pre,
 }
 
 assessment_map_to_their_pre = {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -544,6 +544,132 @@ def test_assessment_end_initial_message(
     new_callable=mock.Mock,
 )
 @mock.patch("ai4gd_momconnect_haystack.api.get_content_from_message_data")
+@mock.patch(
+    "ai4gd_momconnect_haystack.api.assessment_end_flow_map",
+    {
+        "knowledge-pre-assessment": [
+            AssessmentEndScoreBasedMessage.model_validate(
+                {
+                    "message_nr": 1,
+                    "high-score-content": {"content": "KAB High score content"},
+                    "medium-score-content": {"content": "KAB Medium score content"},
+                    "low-score-content": {"content": "KAB Low score content"},
+                    "skipped-many-content": {"content": "KAB Skipped many content"},
+                }
+            )
+        ]
+    },
+)
+def test_assessment_end_initial_message_kab_pre(
+    mock_get_content,
+    mock_save_message,
+    mock_get_history,
+    mock_get_result,
+):
+    """
+    Tests the initial call to the endpoint with no user_input for a KAB pre assessment.
+    It should return the first message of the assessment-end flow.
+    """
+    # --- Mock Setup ---
+    mock_get_result.return_value = AssessmentResult(
+        score=100.0, category="high", crossed_skip_threshold=False
+    )
+    mock_get_history.return_value = []
+    mock_get_content.return_value = ("KAB High score content", None)
+
+    # --- API Call ---
+    client = TestClient(app)
+    response = client.post(
+        "/v1/assessment-end",
+        headers={"Authorization": "Token testtoken"},
+        json={
+            "user_id": "TestUser",
+            "user_input": "",
+            "flow_id": "knowledge-pre-assessment",
+        },
+    )
+
+    # --- Assertions ---
+    assert response.status_code == 200
+    assert response.json() == {
+        "message": "KAB High score content",
+        "task": "",
+        "intent": "JOURNEY_RESPONSE",
+        "intent_related_response": "",
+        "reengagement_info": None,
+    }
+
+    mock_get_result.assert_called_once()
+    mock_get_history.assert_called_once()
+    mock_save_message.assert_called_once_with(
+        "TestUser", "knowledge-pre-assessment", 1, ""
+    )
+
+
+@mock.patch.dict(os.environ, {"API_TOKEN": "testtoken"}, clear=True)
+@mock.patch(
+    "ai4gd_momconnect_haystack.api.get_assessment_result", new_callable=mock.Mock
+)
+@mock.patch(
+    "ai4gd_momconnect_haystack.api.get_assessment_end_messaging_history",
+    new_callable=mock.Mock,
+)
+@mock.patch(
+    "ai4gd_momconnect_haystack.api.save_assessment_end_message",
+    new_callable=mock.Mock,
+)
+@mock.patch("ai4gd_momconnect_haystack.api.get_content_from_message_data")
+def test_assessment_end_initial_message_kab_post(
+    mock_get_content,
+    mock_save_message,
+    mock_get_history,
+    mock_get_result,
+):
+    """
+    Tests the initial call to the endpoint with no user_input for a KAB post assessment.
+    It should return the first message of the assessment-end flow.
+    """
+    mock_get_result.return_value = AssessmentResult(
+        score=100.0, category="high", crossed_skip_threshold=False
+    )
+    mock_get_history.return_value = []
+    mock_get_content.return_value = ("KAB High score content", None)
+
+    client = TestClient(app)
+    response = client.post(
+        "/v1/assessment-end",
+        headers={"Authorization": "Token testtoken"},
+        json={
+            "user_id": "TestUser",
+            "user_input": "",
+            "flow_id": "knowledge-post-assessment",
+        },
+    )
+
+    # Desired behavior once implemented
+    assert response.status_code == 200
+    assert response.json() == {
+        "message": "KAB High score content",
+        "task": "",
+        "intent": "JOURNEY_RESPONSE",
+        "intent_related_response": "",
+        "reengagement_info": None,
+    }
+
+
+@mock.patch.dict(os.environ, {"API_TOKEN": "testtoken"}, clear=True)
+@mock.patch(
+    "ai4gd_momconnect_haystack.api.get_assessment_result", new_callable=mock.Mock
+)
+@mock.patch(
+    "ai4gd_momconnect_haystack.api.get_assessment_end_messaging_history",
+    new_callable=mock.Mock,
+)
+@mock.patch(
+    "ai4gd_momconnect_haystack.api.save_assessment_end_message",
+    new_callable=mock.Mock,
+)
+@mock.patch("ai4gd_momconnect_haystack.api.get_content_from_message_data")
 @mock.patch("ai4gd_momconnect_haystack.api.handle_user_message")
 @mock.patch("ai4gd_momconnect_haystack.api.validate_assessment_end_response")
 @mock.patch("ai4gd_momconnect_haystack.api.determine_task")


### PR DESCRIPTION
This pull request adds support for post-assessment messaging flows for KAB assessments and introduces new tests to ensure this functionality works as intended. Additionally, it includes minor code cleanup in the `utilities.py` file.

**Messaging flow enhancements:**

* Updated the `assessment_end_flow_map` in `utilities.py` to map post-assessment flow IDs (`kab_k_post_flow_id`, `kab_a_post_flow_id`, `kab_b_post_flow_id`) to the same messaging flows as their pre-assessment counterparts, enabling consistent messaging for both pre and post assessments.

**Testing improvements:**

* Added two new tests to `test_api.py`:
  - [`test_assessment_end_initial_message_kab_pre`](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79R534-R659): Verifies the initial endpoint response for a KAB pre-assessment.
  - [`test_assessment_end_initial_message_kab_post`](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79R534-R659): Verifies the initial endpoint response for a KAB post-assessment, ensuring parity with pre-assessment messaging.

**Code cleanup:**

* Minor reordering and removal of unused imports in `utilities.py` for improved readability and maintainability. [[1]](diffhunk://#diff-5e6c98453cda82c920bbdfd4b197aecea405ae95c131f62f5e374bf090e27e6eL1-R7) [[2]](diffhunk://#diff-5e6c98453cda82c920bbdfd4b197aecea405ae95c131f62f5e374bf090e27e6eL16)