### PR TITLE
Fix post kab behaviour assessment questions

### DIFF
--- a/src/ai4gd_momconnect_haystack/doc_store.py
+++ b/src/ai4gd_momconnect_haystack/doc_store.py
@@ -22,8 +22,8 @@ from ai4gd_momconnect_haystack.pydantic_models import (
     ANCSurveyQuestion,
     AssessmentEndItem,
     AssessmentQuestion,
-    OnboardingQuestion,
     IntroductionMessage,
+    OnboardingQuestion,
 )
 
 # --- Configurations ---
@@ -110,11 +110,20 @@ kab_b_pre_flow = load_content_json_and_validate(
 assert kab_b_pre_flow is not None, "Failed to load the KAB Behaviour (pre) flow."
 KAB_B_PRE_FLOW: list[AssessmentQuestion] = kab_b_pre_flow
 
+# Merge KAB Behaviour pre and post flows, with post overriding pre by question_number
+all_b_kab_questions = {q.question_number: q for q in KAB_B_PRE_FLOW}
+
 kab_b_post_flow = load_content_json_and_validate(
     data_dir / "kab.json", AssessmentQuestion, "behaviour-post-assessment"
 )
-assert kab_b_post_flow is not None, "Failed to load the KAB Behaviour (post) flow."
-KAB_B_POST_FLOW: list[AssessmentQuestion] = kab_b_post_flow
+
+if kab_b_post_flow:
+    for q in kab_b_post_flow:
+        all_b_kab_questions[q.question_number] = q
+
+KAB_B_POST_FLOW: list[AssessmentQuestion] = [
+    all_b_kab_questions[q_num] for q_num in sorted(all_b_kab_questions)
+]
 
 # Assessment End Messaging Data
 dma_assessment_end_flow: list[AssessmentEndItem] | None = (

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1244,6 +1244,56 @@ def test_extract_assessment_data_from_response_with_mocking(
     )
 
 
+@mock.patch(
+    "ai4gd_momconnect_haystack.tasks.pipelines.run_behaviour_data_extraction_pipeline"
+)
+def test_extract_assessment_data_from_response_post_kab(mock_run_pipeline):
+    """
+    Tests the extract_assessment_data_from_response function for the 'behaviour-post-assessment' flow,
+    specifically for the first question regarding clinic visits during pregnancy.
+
+    This test:
+    - Mocks the AI pipeline to return a fixed response.
+    - Sets up the expected question content and valid responses.
+    - Asserts that the function returns the correct processed response and next question number.
+    - Verifies that the AI pipeline is called with the correct arguments.
+    """
+    # Arrange: Configure the mock to return the expected answer for this test run.
+    mock_run_pipeline.return_value = "test"
+
+    # The question data the function will look up
+    question_content = "Excellent 👍🏽\n\nIf you want to skip a question, just type and send `skip`.\n\n*So far in this pregnancy, how many times have you gone to the clinic for a pregnancy check-up?* 🫃🏽"
+
+    # Act: Call the function that we are testing
+    result = extract_assessment_data_from_response(
+        user_response="5",
+        flow_id="behaviour-post-assessment",
+        question_number=1,
+    )
+
+    # Assert
+    # 1. Check that the function returned the correct structure with the mocked data.
+    assert result["processed_user_response"] == "test"
+    assert result["next_question_number"] == 2
+
+    # 2. Verify that our function called the AI pipeline correctly.
+    mock_run_pipeline.assert_called_once_with(
+        user_response="5",
+        previous_service_message=question_content,
+        valid_responses=[
+            "0 - None",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "More than 7",
+        ],  # The options for this specific question
+    )
+
+
 # --- NEW TESTS FOR ONBOARDING LOGIC ---
 # Define mock data for our test questions to use across multiple test cases.
 PROVINCE_QUESTION_MOCK_DATA = {


### PR DESCRIPTION
This pull request introduces an important update to how KAB Behaviour assessment questions are managed and tested. The main change is the merging of pre- and post-assessment question flows, ensuring that post-assessment questions override pre-assessment ones where applicable. Additionally, a new targeted test is added for the behaviour-post-assessment flow, improving coverage and reliability. There is also a minor code reordering for clarity.

**Assessment Question Flow Improvements:**

* Merged KAB Behaviour pre- and post-assessment flows in `doc_store.py`, with post-assessment questions overriding pre-assessment ones by `question_number`, ensuring a unified and up-to-date list for the behaviour assessment.

**Testing Enhancements:**

* Added a new test `test_extract_assessment_data_from_response_post_kab` to verify correct processing and AI pipeline invocation for the first question in the behaviour-post-assessment flow, increasing test coverage and reliability.

**Code Organization:**

* Reordered the import of `OnboardingQuestion` in `doc_store.py` for improved readability and consistency.