### PR TITLE
Enhance KAB flow handling in reminder requests and add tests

### DIFF
--- a/src/ai4gd_momconnect_haystack/tasks.py
+++ b/src/ai4gd_momconnect_haystack/tasks.py
@@ -1095,7 +1095,8 @@ def handle_reminder_request(
     schedule_key = "default"
     if "onboarding" in flow_id:
         schedule_key = "onboarding"
-    elif "behaviour" in flow_id:
+    # Treat KAB flows (behaviour, knowledge, attitude) the same
+    elif any(k in flow_id for k in ("behaviour", "knowledge", "attitude")):
         schedule_key = "kab"
     elif "survey" in flow_id:
         schedule_key = "survey"


### PR DESCRIPTION
This pull request improves the handling and testing of reminder scheduling for KAB (Knowledge, Attitude, Behaviour) flows. The main focus is on treating these flows consistently and ensuring the correct acknowledgement messages and trigger times are used. Key changes include updating the logic for identifying KAB flows and adding comprehensive tests for their reminder behavior.

**Reminder scheduling logic improvements:**
- Updated the `handle_reminder_request` function to treat "knowledge" and "attitude" flows the same as "behaviour" by mapping them all to the `kab` schedule key.

**Testing enhancements:**
- Added a new parameterized test, `test_handle_reminder_request_kab_acknowledgements`, to verify that KAB flows use the correct acknowledgement message and trigger time based on the reminder type, referencing `REMINDER_CONFIG`.
- Updated imports in `tests/test_tasks.py` to include `REMINDER_CONFIG` for use in the new tests.…tests