### PR TITLE
Refactor reminder requests to set reminder_type.

### DIFF
--- a/src/ai4gd_momconnect_haystack/api.py
+++ b/src/ai4gd_momconnect_haystack/api.py
@@ -675,11 +675,8 @@ def assessment(request: AssessmentRequest, token: str = Depends(verify_token)):
                 )
                 failure_count = 0
         elif intent == "REQUEST_TO_BE_REMINDED":
-            state = get_user_journey_state(request.user_id)
-            current_reminder_count = state.reminder_count if state else 0
-            new_reminder_count = current_reminder_count + 1
-            reminder_type = 2 if new_reminder_count >= 2 else 1
-            request.user_context["reminder_count"] = new_reminder_count
+            # For user requested reminders the type is always 2 for next day
+            reminder_type = 2
 
             message, reengagement_info = handle_reminder_request(
                 user_id=request.user_id,


### PR DESCRIPTION
This pull request updates the reminder logic for user-requested reminders and improves the corresponding test to ensure deterministic and accurate validation of reminder scheduling. The main focus is to standardize the reminder type for user-initiated reminders and to make the test robust against timing issues.

**Reminder logic changes:**

* The logic in the `assessment` endpoint was updated so that user-requested reminders always use `reminder_type = 2` (next day), regardless of previous reminders, simplifying the reminder scheduling rules.

**Testing improvements:**

* In `test_reminder_request_returns_reengagement_info`, the test now freezes the current time and patches the reminder logic to use this fixed time, making the expected trigger time deterministic and ensuring the test reliably checks the scheduled reminder's timing.
* The test was extended to assert that the returned `reengagement_info` has the correct `type`, `flow_id`, `reminder_type`, and that the `trigger_at_utc` field matches the expected time exactly.
* Added necessary imports for `datetime`, `timedelta`, and `timezone` to support the new test logic