### PR TITLE
Update reminder handling in assessment end to pass additional flag 

### DIFF
--- a/src/ai4gd_momconnect_haystack/api.py
+++ b/src/ai4gd_momconnect_haystack/api.py
@@ -824,7 +824,9 @@ def assessment_end(request: AssessmentEndRequest, token: str = Depends(verify_to
         state = get_user_journey_state(request.user_id)
         if state and state.current_step_identifier == "awaiting_reminder_response":
             logger.info("User is responding to a reminder prompt.")
-            return handle_reminder_response(request.user_id, request.user_input, state)
+            return handle_reminder_response(
+                request.user_id, request.user_input, state, True
+            )
 
         # User has responded, process their input
         if not previous_message_nr or previous_message_nr not in flow_content_map:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1019,7 +1019,7 @@ def test_assessment_end_response_to_awaiting_reminder(mock_get_result):
     # For an assessment flow we expect the journey to be resumed
     assert json_resp["intent"] == "JOURNEY_RESUMED"
     # The original last question should be re-sent
-    assert json_resp["question"] == "Please reply"
+    assert json_resp["message"] == "Please reply"
 
 
 @mock.patch.dict(os.environ, {"API_TOKEN": "testtoken"}, clear=True)
@@ -1067,7 +1067,7 @@ def test_assessment_end_response_to_awaiting_reminder_request_reminder(mock_get_
     # For an assessment flow we expect the journey to be resumed
     assert json_resp["intent"] == "REQUEST_TO_BE_REMINDED"
     # The original last question should be re-sent
-    assert "Great! We’ll remind you tomorrow" in json_resp["question"]
+    assert "Great! We’ll remind you tomorrow" in json_resp["message"]
 
 
 @mock.patch.dict(os.environ, {"API_TOKEN": "testtoken"}, clear=True)
@@ -1115,7 +1115,7 @@ def test_assessment_end_response_to_awaiting_reminder_ambiguous(mock_get_result)
     # For an assessment flow we expect the journey to be resumed
     assert json_resp["intent"] == "REPAIR"
     # The original last question should be re-sent
-    assert "Hi! Ready to pick up where you left off?" in json_resp["question"]
+    assert "Hi! Ready to pick up where you left off?" in json_resp["message"]
 
 
 @mock.patch.dict(


### PR DESCRIPTION
This pull request updates the handling of responses to reminder prompts in the assessment flow and aligns the API response structure with the expected output in tests. The main changes are grouped into improvements in reminder response handling and test consistency.

Reminder response handling:

* The call to `handle_reminder_response` in `assessment_end` now passes an additional argument (`True`) to indicate the context when the user is responding to a reminder prompt.

Test consistency and API output alignment:

* In multiple test cases (`test_assessment_end_response_to_awaiting_reminder`, `test_assessment_end_response_to_awaiting_reminder_request_reminder`, and `test_assessment_end_response_to_awaiting_reminder_ambiguous`), assertions have been updated to check the `message` field instead of `question` in the API response, reflecting a change in the response structure. [[1]](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79L1022-R1022) [[2]](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79L1070-R1070) [[3]](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79L1118-R1118)