### PR TITLE
Allow users to redo assessments with skipped questions

### DIFF
--- a/src/ai4gd_momconnect_haystack/assessment_logic.py
+++ b/src/ai4gd_momconnect_haystack/assessment_logic.py
@@ -455,9 +455,9 @@ def create_assessment_end_error_response(reason: str) -> AssessmentEndResponse:
 
 def response_is_required_for(flow_id: str, message_nr: int) -> bool:
     required_map = {
-        "dma-pre-assessment": [2, 3],
-        "behaviour-pre-assessment": [2],
-        "knowledge-pre-assessment": [2],
-        "attitude-pre-assessment": [2],
+        "dma-pre-assessment": [1, 2, 3],
+        "behaviour-pre-assessment": [1, 2],
+        "knowledge-pre-assessment": [1, 2],
+        "attitude-pre-assessment": [1, 2],
     }
     return message_nr in required_map.get(flow_id, [])

--- a/src/ai4gd_momconnect_haystack/static_content/assessment_ends.json
+++ b/src/ai4gd_momconnect_haystack/static_content/assessment_ends.json
@@ -17,6 +17,10 @@
             "skipped-many-content": {
                 "content": "You skipped more than half the questions, so we can't tell how you feel about healthcare 😞\n\nIt would be great if you could answer them when you feel ready.\n\nCan we remind you tomorrow?",
                 "valid_responses": ["Yes","No"]
+            },
+            "response_required": {
+                "default": false,
+                "skipped-many": true
             }
         },
         {
@@ -53,6 +57,10 @@
             "skipped-many-content": {
                 "content": "We noticed you skipped some of the questions in this section. We can remind you about them tomorrow.\n\nThere are 8 more new questions to do in this health check. Do you want to do them now and finish it?\n\nReply with 'Yes' or 'Remind me tomorrow'",
                 "valid_responses": ["Yes","Remind me tomorrow"]
+            },
+            "response_required": {
+                "default": false,
+                "skipped-many": true
             }
         }
     ],
@@ -74,6 +82,10 @@
             "skipped-many-content": {
                 "content": "We noticed you skipped some of the questions in this section. We can remind you about them tomorrow.\n\nThere are 3 new questions to do in this health check. Do you want to do them now and finish it?\n\nReply with 'Yes' or 'Remind me tomorrow'",
                 "valid_responses": ["Yes","Remind me tomorrow"]
+            },
+            "response_required": {
+                "default": false,
+                "skipped-many": true
             }
         }
     ],
@@ -113,6 +125,10 @@
             "skipped-many-content": {
                 "content": "We noticed you skipped some of your questions.\n\nCan we remind you to answer them again tomorrow? Reply with 'Yes' or 'No'.",
                 "valid_responses": ["Yes","No"]
+            },
+            "response_required": {
+                "default": false,
+                "skipped-many": true
             }
         },
         {


### PR DESCRIPTION
**Description**
This PR introduces an enhanced user journey for the `/v1/assessment-end` flow. When a user completes a DMA or KAB assessment having skipped more than half the questions, they are now presented with a specific prompt instead of the standard end-of-assessment message.

This new prompt allows the user to choose between two paths:
1. Be reminded the next day to retake the assessment.
2. Proceed with the standard post-assessment feedback questions.

Changes

- `api.py`: Added a logic block to the assessment_end handler that is triggered when score_category is "skipped-many" and the user is responding to the first message.
    - If a reminder is requested, handle_reminder_request is called with step_identifier="1" to ensure the user restarts at the first question, skipping the intro.
    - If the user chooses to proceed, the function's default behavior continues, advancing them to the next message in the end-of-assessment flow.
- `assessment_ends.json`: Updated the `message_nr: 1` object for all four relevant assessments to include `"response_required": { "skipped-many": true }`. This was the critical fix to ensure the API processes the user's response in this scenario.
- `test_api.py`: Added a new, comprehensive parametrised unit test, `test_assessment_end_skipped_many_scenarios`, which covers all branches of the new logic for both DMA and KAB assessment patterns.